### PR TITLE
Fix allocator size alignment

### DIFF
--- a/src/utils/allocator.rs
+++ b/src/utils/allocator.rs
@@ -101,16 +101,17 @@ impl GpuAllocator {
             return Some(alloc);
         }
         let aligned_offset = Self::align_up(self.current_offset, self.alignment);
-        let end = aligned_offset + size;
+        let end = aligned_offset + aligned_size;
 
         if end > self.capacity {
             return None;
         }
 
         let alloc = Allocation {
-            buffer: unsafe { &mut *(self.ctx) }.suballoc_from(self.buffer, aligned_offset as u32, size as u32)?,
+            buffer: unsafe { &mut *(self.ctx) }
+                .suballoc_from(self.buffer, aligned_offset as u32, aligned_size as u32)?,
             offset: aligned_offset,
-            size,
+            size: aligned_size,
         };
 
         self.current_offset = end;


### PR DESCRIPTION
## Summary
- ensure GPU allocator advances by aligned block sizes
- use aligned size when suballocating buffers and storing allocation info

## Testing
- `cargo test --lib` *(fails: couldn't complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6843124827a4832aa62cc7f872daad0d