### PR TITLE
Use headless context in tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,15 +374,11 @@ impl RenderPassBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dashi::{gpu, DeviceFilter, DeviceSelector};
+    use dashi::gpu;
     use serial_test::serial;
 
     fn init_ctx() -> gpu::Context {
-        let device = DeviceSelector::new()
-            .unwrap()
-            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
-            .unwrap_or_default();
-        gpu::Context::new(&crate::ContextInfo { device }).unwrap()
+        gpu::Context::headless(&Default::default()).unwrap()
     }
 
     #[test]

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -643,11 +643,7 @@ mod tests {
     }
 
     fn setup_ctx() -> gpu::Context {
-        let device = DeviceSelector::new()
-            .unwrap()
-            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
-            .unwrap_or_default();
-        gpu::Context::new(&ContextInfo { device }).unwrap()
+        gpu::Context::headless(&Default::default()).unwrap()
     }
 
     #[test]

--- a/src/utils/allocator.rs
+++ b/src/utils/allocator.rs
@@ -134,15 +134,11 @@ impl GpuAllocator {
 #[cfg(test)]
 mod test {
     use super::*;
-    use dashi::{gpu, DeviceFilter, DeviceSelector};
+    use dashi::gpu;
     use serial_test::serial;
 
     fn init_ctx() -> gpu::Context {
-        let device = DeviceSelector::new()
-            .unwrap()
-            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
-            .unwrap_or_default();
-        gpu::Context::new(&crate::ContextInfo { device }).unwrap()
+        gpu::Context::headless(&Default::default()).unwrap()
     }
 
     #[test]

--- a/src/utils/dhobject.rs
+++ b/src/utils/dhobject.rs
@@ -86,11 +86,7 @@ mod test {
     #[test]
     #[serial]
     fn test_dhobject_allocation_and_write() {
-        let device = DeviceSelector::new()
-            .unwrap()
-            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
-            .unwrap_or_default();
-        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        let mut ctx = Context::headless(&Default::default()).unwrap();
 
         let mut allocator = GpuAllocator::new(&mut ctx, 1024, BufferUsage::UNIFORM, 16).unwrap();
 
@@ -114,11 +110,7 @@ mod test {
     #[test]
     #[serial]
     fn multiple_dh_objects_and_drop() {
-        let device = DeviceSelector::new()
-            .unwrap()
-            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
-            .unwrap_or_default();
-        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        let mut ctx = Context::headless(&Default::default()).unwrap();
 
         let mut allocator = GpuAllocator::new(&mut ctx, 1024, BufferUsage::UNIFORM, 16).unwrap();
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -234,16 +234,12 @@ impl ResourceManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dashi::{gpu, DeviceFilter, DeviceSelector};
+    use dashi::gpu;
     use serial_test::serial;
     use std::sync::Arc;
 
     fn setup_ctx() -> gpu::Context {
-        let device = DeviceSelector::new()
-            .unwrap()
-            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
-            .unwrap_or_default();
-        gpu::Context::new(&ContextInfo { device }).unwrap()
+        gpu::Context::headless(&Default::default()).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- switch internal tests to use `gpu::Context::headless(&Default::default())`

## Testing
- `cargo fmt` *(fails: rustfmt component missing)*
- `cargo test --lib -- --test-threads=1 --nocapture` *(failed to finish)*

------
https://chatgpt.com/codex/tasks/task_e_684323b85acc832a84d2dd371c7b2888