### PR TITLE
Add simple skeletal animation system

### DIFF
--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,0 +1,81 @@
+use glam::Mat4;
+
+#[derive(Clone, Debug)]
+pub struct Bone {
+    pub name: String,
+    pub parent: Option<usize>,
+    pub inverse_bind: Mat4,
+}
+
+#[derive(Clone, Debug)]
+pub struct Skeleton {
+    pub bones: Vec<Bone>,
+}
+
+impl Skeleton {
+    pub fn bone_count(&self) -> usize {
+        self.bones.len()
+    }
+}
+
+pub struct Animator {
+    pub skeleton: Skeleton,
+    pub matrices: Vec<Mat4>,
+}
+
+impl Animator {
+    pub fn new(skeleton: Skeleton) -> Self {
+        let matrices = vec![Mat4::IDENTITY; skeleton.bone_count()];
+        Self { skeleton, matrices }
+    }
+
+    pub fn update(&mut self, local: &[Mat4]) {
+        assert_eq!(local.len(), self.skeleton.bone_count());
+        for (i, bone) in self.skeleton.bones.iter().enumerate() {
+            let parent_world = bone
+                .parent
+                .and_then(|p| self.matrices.get(p).cloned())
+                .unwrap_or(Mat4::IDENTITY);
+            let world = parent_world * local[i];
+            self.matrices[i] = world * bone.inverse_bind;
+        }
+    }
+
+    pub fn matrices(&self) -> &[Mat4] {
+        &self.matrices
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::{Mat4, Vec3};
+
+    #[test]
+    fn simple_hierarchy_updates() {
+        let bones = vec![
+            Bone {
+                name: "root".into(),
+                parent: None,
+                inverse_bind: Mat4::IDENTITY,
+            },
+            Bone {
+                name: "child".into(),
+                parent: Some(0),
+                inverse_bind: Mat4::IDENTITY,
+            },
+        ];
+        let skeleton = Skeleton { bones };
+        let mut animator = Animator::new(skeleton);
+        let local = vec![
+            Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0)),
+            Mat4::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+        ];
+        animator.update(&local);
+        let mats = animator.matrices();
+        let root_pos = mats[0].transform_point3(Vec3::ZERO);
+        let child_pos = mats[1].transform_point3(Vec3::ZERO);
+        assert_eq!(root_pos, Vec3::new(1.0, 0.0, 0.0));
+        assert_eq!(child_pos, Vec3::new(1.0, 0.0, 1.0));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod material;
 pub mod utils;
 pub mod renderer;
+pub mod animation;
 pub use utils::*;
 pub use material::*;
 use dashi::utils::*;

--- a/src/renderer/drawable.rs
+++ b/src/renderer/drawable.rs
@@ -2,6 +2,8 @@
 //! These may expand to support more mesh/material types and instancing.
 use dashi::*;
 use dashi::{utils::Handle, *};
+use glam::Mat4;
+use crate::animation::Skeleton;
 
 use bytemuck::{Pod, Zeroable};
 
@@ -87,6 +89,13 @@ impl SkeletalMesh {
         } else {
             self.index_count = self.vertices.len();
         }
+        self.bone_buffer = Some(ctx.make_buffer(&BufferInfo {
+            debug_name: "skel_bone_buffer",
+            byte_size: (self.skeleton.bone_count() * std::mem::size_of::<Mat4>()) as u32,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::STORAGE,
+            initial_data: None,
+        })?);
         Ok(())
     }
 }
@@ -99,4 +108,6 @@ pub struct SkeletalMesh {
     pub vertex_buffer: Option<Handle<Buffer>>,
     pub index_buffer: Option<Handle<Buffer>>,
     pub index_count: usize,
+    pub skeleton: Skeleton,
+    pub bone_buffer: Option<Handle<Buffer>>,
 }

--- a/src/renderer/skinning.vert
+++ b/src/renderer/skinning.vert
@@ -1,0 +1,24 @@
+#version 450
+layout(location = 0) in vec3 inPos;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec4 inTangent;
+layout(location = 3) in vec2 inUV;
+layout(location = 4) in vec4 inColor;
+layout(location = 5) in uvec4 inJoints;
+layout(location = 6) in vec4 inWeights;
+
+layout(set = 0, binding = 0) readonly buffer Bones {
+    mat4 bones[];
+} bone_buf;
+
+layout(location = 0) out vec4 vColor;
+
+void main() {
+    mat4 skin =
+        inWeights.x * bone_buf.bones[inJoints.x] +
+        inWeights.y * bone_buf.bones[inJoints.y] +
+        inWeights.z * bone_buf.bones[inJoints.z] +
+        inWeights.w * bone_buf.bones[inJoints.w];
+    gl_Position = skin * vec4(inPos, 1.0);
+    vColor = inColor;
+}


### PR DESCRIPTION
## Summary
- implement `animation` module with `Skeleton` and `Animator`
- extend `SkeletalMesh` with skeleton reference and bone buffer
- add GLSL skinning shader
- expose animation module in crate root

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843462aa9cc832aa937e08e8f5c4b1d