### PR TITLE
Extract shaders to files and include via include_spirv

### DIFF
--- a/shaders/deferred.vert
+++ b/shaders/deferred.vert
@@ -1,0 +1,5 @@
+#version 450
+layout(location = 0) in vec2 inPosition;
+void main() {
+    gl_Position = vec4(inPosition, 0.0, 1.0);
+}

--- a/shaders/gbuffer.frag
+++ b/shaders/gbuffer.frag
@@ -1,0 +1,7 @@
+#version 450
+layout(location = 0) out vec4 outAlbedo;
+layout(location = 1) out vec4 outNormal;
+void main() {
+    outAlbedo = vec4(1.0, 0.0, 0.0, 1.0);
+    outNormal = vec4(0.0, 0.0, 1.0, 1.0);
+}

--- a/shaders/lighting.frag
+++ b/shaders/lighting.frag
@@ -1,0 +1,5 @@
+#version 450
+layout(location = 0) out vec4 outColor;
+void main() {
+    outColor = vec4(1.0);
+}

--- a/shaders/sample.frag
+++ b/shaders/sample.frag
@@ -1,0 +1,9 @@
+#version 450
+layout(set = 0, binding = 0) uniform sampler2D tex;
+layout(set = 0, binding = 1) uniform UBO { float v; } ubo;
+layout(location = 0) in vec2 uv;
+layout(location = 0) out vec4 outColor;
+void main() {
+    vec4 color = texture(tex, uv);
+    outColor = mix(color, vec4(0.0, 1.0, 0.0, 1.0), ubo.v);
+}

--- a/shaders/sample.vert
+++ b/shaders/sample.vert
@@ -1,0 +1,7 @@
+#version 450
+layout(location = 0) in vec2 inPosition;
+layout(location = 0) out vec2 uv;
+void main() {
+    uv = inPosition * 0.5 + vec2(0.5, 0.5);
+    gl_Position = vec4(inPosition, 0.0, 1.0);
+}

--- a/shaders/shadow_pass.frag
+++ b/shaders/shadow_pass.frag
@@ -1,0 +1,2 @@
+#version 450
+void main() {}

--- a/shaders/shadows.vert
+++ b/shaders/shadows.vert
@@ -1,0 +1,18 @@
+#version 450
+layout(set = 0, binding = 0) uniform Camera {
+    mat4 view_proj;
+};
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+
+layout(location = 0) out vec3 worldPos;
+layout(location = 1) out vec3 normal;
+
+void main() {
+    mat4 model = mat4(1.0);
+    vec4 world = model * vec4(inPosition, 1.0);
+    worldPos = world.xyz;
+    normal = mat3(model) * inNormal;
+    gl_Position = view_proj * world;
+}

--- a/shaders/shadows_lit.frag
+++ b/shaders/shadows_lit.frag
@@ -1,0 +1,20 @@
+#version 450
+layout(location = 0) in vec3 vWorldPos;
+layout(location = 1) in vec3 vNormal;
+
+layout(set = 0, binding = 1) uniform sampler2DShadow shadowMap;
+
+layout(location = 0) out vec4 outColor;
+
+void main() {
+    vec3 lightDir = normalize(vec3(-0.5, -1.0, -0.3));
+    vec3 normal = normalize(vNormal);
+    float NdotL = max(dot(normal, -lightDir), 0.0);
+
+    // Sample the shadow map
+    float shadow = texture(shadowMap, vec3(vWorldPos.xy * 0.5 + 0.5, vWorldPos.z));
+
+    // Combine lighting with shadow factor
+    vec3 litColor = vec3(1.0, 1.0, 0.8) * NdotL * shadow;
+    outColor = vec4(litColor, 1.0);
+}

--- a/shaders/test_triangle.frag
+++ b/shaders/test_triangle.frag
@@ -1,0 +1,6 @@
+#version 450
+layout(location = 0) in vec4 vColor;
+layout(location = 0) out vec4 outColor;
+void main() {
+    outColor = vColor;
+}

--- a/shaders/test_triangle.vert
+++ b/shaders/test_triangle.vert
@@ -1,0 +1,11 @@
+#version 450
+layout(location = 0) in vec3 inPos;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec4 inTangent;
+layout(location = 3) in vec2 inUV;
+layout(location = 4) in vec4 inColor;
+layout(location = 0) out vec4 vColor;
+void main() {
+    vColor = inColor;
+    gl_Position = vec4(inPos, 1.0);
+}

--- a/test/sample/bin.rs
+++ b/test/sample/bin.rs
@@ -3,6 +3,7 @@ use dashi::*;
 use koji::*;
 use sdl2::{event::Event, keyboard::Keycode};
 use std::sync::Arc;
+// Shaders are stored under `shaders/` and compiled at build time using `include_spirv!`.
 
 pub fn main() {
     let device = DeviceSelector::new()
@@ -72,33 +73,17 @@ pub fn render_sample_model(ctx: &mut Context, rp: Handle<RenderPass>, targets: &
     let uniform_value: f32 = 0.7;
 
     // ==== NEW: Set up PipelineBuilder shaders ====
-    let vert_spirv = inline_spirv::inline_spirv!(
-        r#"
-        #version 450
-        layout(location = 0) in vec2 inPosition;
-        layout(location = 0) out vec2 uv;
-        void main() {
-            uv = inPosition * 0.5 + vec2(0.5, 0.5);
-            gl_Position = vec4(inPosition, 0.0, 1.0);
-        }
-        "#,
+    let vert_spirv = inline_spirv::include_spirv!(
+        "shaders/sample.vert",
         vert
-    ).to_vec();
+    )
+    .to_vec();
 
-    let frag_spirv = inline_spirv::inline_spirv!(
-        r#"
-        #version 450
-        layout(set = 0, binding = 0) uniform sampler2D tex;
-        layout(set = 0, binding = 1) uniform UBO { float v; } ubo;
-        layout(location = 0) in vec2 uv;
-        layout(location = 0) out vec4 outColor;
-        void main() {
-            vec4 color = texture(tex, uv);
-            outColor = mix(color, vec4(0.0, 1.0, 0.0, 1.0), ubo.v);
-        }
-        "#,
+    let frag_spirv = inline_spirv::include_spirv!(
+        "shaders/sample.frag",
         frag
-    ).to_vec();
+    )
+    .to_vec();
 
     let mut pso = PipelineBuilder::new(ctx, "sample_pso")
         .vertex_shader(&vert_spirv)

--- a/test/sample_deferred/bin.rs
+++ b/test/sample_deferred/bin.rs
@@ -1,10 +1,11 @@
 // src/deferred_render.rs
 use dashi::utils::*;
 use dashi::*;
-use inline_spirv::inline_spirv;
+use inline_spirv::include_spirv;
 use koji::*;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
+// Shader sources live in `shaders/` and are included with `include_spirv!`.
 use std::time::Instant;
 
 pub fn run(ctx: &mut Context) {
@@ -57,12 +58,8 @@ pub fn run(ctx: &mut Context) {
 
     let vert = PipelineShaderInfo {
         stage: ShaderType::Vertex,
-        spirv: inline_spirv!(
-            r#"#version 450
-            layout(location = 0) in vec2 inPosition;
-            void main() {
-                gl_Position = vec4(inPosition, 0.0, 1.0);
-            }"#,
+        spirv: include_spirv!(
+            "shaders/deferred.vert",
             vert
         ),
         specialization: &[],
@@ -70,14 +67,8 @@ pub fn run(ctx: &mut Context) {
 
     let frag_gbuffer = PipelineShaderInfo {
         stage: ShaderType::Fragment,
-        spirv: inline_spirv!(
-            r#"#version 450
-            layout(location = 0) out vec4 outAlbedo;
-            layout(location = 1) out vec4 outNormal;
-            void main() {
-                outAlbedo = vec4(1.0, 0.0, 0.0, 1.0);
-                outNormal = vec4(0.0, 0.0, 1.0, 1.0);
-            }"#,
+        spirv: include_spirv!(
+            "shaders/gbuffer.frag",
             frag
         ),
         specialization: &[],
@@ -85,12 +76,8 @@ pub fn run(ctx: &mut Context) {
 
     let frag_lighting = PipelineShaderInfo {
         stage: ShaderType::Fragment,
-        spirv: inline_spirv!(
-            r#"#version 450
-            layout(location = 0) out vec4 outColor;
-            void main() {
-                outColor = vec4(1.0); // White lighting for now
-            }"#,
+        spirv: include_spirv!(
+            "shaders/lighting.frag",
             frag
         ),
         specialization: &[],

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -4,8 +4,9 @@ use koji::renderer::*;
 use koji::utils::*;
 use dashi::*;
 use bytemuck::{Pod, Zeroable};
-use inline_spirv::inline_spirv;
+use inline_spirv::include_spirv;
 use serial_test::serial;
+// External shader files are loaded from `shaders/` using `include_spirv!`.
 
 fn make_color_vertex(position: [f32; 3], color: [f32; 4]) -> Vertex {
     Vertex {
@@ -58,36 +59,19 @@ fn cube_indices() -> Vec<u32> {
 }
 
 fn make_shader_vert() -> Vec<u32> {
-    inline_spirv!(
-        r#"
-        #version 450
-        layout(location = 0) in vec3 inPos;
-        layout(location = 1) in vec3 inNormal;
-        layout(location = 2) in vec4 inTangent;
-        layout(location = 3) in vec2 inUV;
-        layout(location = 4) in vec4 inColor;
-        layout(location = 0) out vec4 vColor;
-        void main() {
-            vColor = inColor;
-            gl_Position = vec4(inPos, 1.0);
-        }
-        "#,
+    include_spirv!(
+        "shaders/test_triangle.vert",
         vert
-    ).to_vec()
+    )
+    .to_vec()
 }
 
 fn make_shader_frag() -> Vec<u32> {
-    inline_spirv!(
-        r#"
-        #version 450
-        layout(location = 0) in vec4 vColor;
-        layout(location = 0) out vec4 outColor;
-        void main() {
-            outColor = vColor;
-        }
-        "#,
+    include_spirv!(
+        "shaders/test_triangle.frag",
         frag
-    ).to_vec()
+    )
+    .to_vec()
 }
 
 #[test]

--- a/tests/sample/bin.rs
+++ b/tests/sample/bin.rs
@@ -3,6 +3,7 @@ use dashi::*;
 use koji::*;
 use sdl2::{event::Event, keyboard::Keycode};
 use std::sync::Arc;
+// Shaders are stored under `shaders/` and compiled at build time using `include_spirv!`.
 
 pub fn main() {
     let device = DeviceSelector::new()
@@ -72,33 +73,17 @@ pub fn render_sample_model(ctx: &mut Context, rp: Handle<RenderPass>, targets: &
     let uniform_value: f32 = 0.7;
 
     // ==== NEW: Set up PipelineBuilder shaders ====
-    let vert_spirv = inline_spirv::inline_spirv!(
-        r#"
-        #version 450
-        layout(location = 0) in vec2 inPosition;
-        layout(location = 0) out vec2 uv;
-        void main() {
-            uv = inPosition * 0.5 + vec2(0.5, 0.5);
-            gl_Position = vec4(inPosition, 0.0, 1.0);
-        }
-        "#,
+    let vert_spirv = inline_spirv::include_spirv!(
+        "shaders/sample.vert",
         vert
-    ).to_vec();
+    )
+    .to_vec();
 
-    let frag_spirv = inline_spirv::inline_spirv!(
-        r#"
-        #version 450
-        layout(set = 0, binding = 0) uniform sampler2D tex;
-        layout(set = 0, binding = 1) uniform UBO { float v; } ubo;
-        layout(location = 0) in vec2 uv;
-        layout(location = 0) out vec4 outColor;
-        void main() {
-            vec4 color = texture(tex, uv);
-            outColor = mix(color, vec4(0.0, 1.0, 0.0, 1.0), ubo.v);
-        }
-        "#,
+    let frag_spirv = inline_spirv::include_spirv!(
+        "shaders/sample.frag",
         frag
-    ).to_vec();
+    )
+    .to_vec();
 
     let mut pso = PipelineBuilder::new(ctx, "sample_pso")
         .vertex_shader(&vert_spirv)

--- a/tests/sample_deferred/bin.rs
+++ b/tests/sample_deferred/bin.rs
@@ -1,10 +1,11 @@
 // src/deferred_render.rs
 use dashi::utils::*;
 use dashi::*;
-use inline_spirv::inline_spirv;
+use inline_spirv::include_spirv;
 use koji::*;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
+// Shader sources live in `shaders/` and are included with `include_spirv!`.
 use std::time::Instant;
 
 pub fn run(ctx: &mut Context) {
@@ -57,12 +58,8 @@ pub fn run(ctx: &mut Context) {
 
     let vert = PipelineShaderInfo {
         stage: ShaderType::Vertex,
-        spirv: inline_spirv!(
-            r#"#version 450
-            layout(location = 0) in vec2 inPosition;
-            void main() {
-                gl_Position = vec4(inPosition, 0.0, 1.0);
-            }"#,
+        spirv: include_spirv!(
+            "shaders/deferred.vert",
             vert
         ),
         specialization: &[],
@@ -70,14 +67,8 @@ pub fn run(ctx: &mut Context) {
 
     let frag_gbuffer = PipelineShaderInfo {
         stage: ShaderType::Fragment,
-        spirv: inline_spirv!(
-            r#"#version 450
-            layout(location = 0) out vec4 outAlbedo;
-            layout(location = 1) out vec4 outNormal;
-            void main() {
-                outAlbedo = vec4(1.0, 0.0, 0.0, 1.0);
-                outNormal = vec4(0.0, 0.0, 1.0, 1.0);
-            }"#,
+        spirv: include_spirv!(
+            "shaders/gbuffer.frag",
             frag
         ),
         specialization: &[],
@@ -85,12 +76,8 @@ pub fn run(ctx: &mut Context) {
 
     let frag_lighting = PipelineShaderInfo {
         stage: ShaderType::Fragment,
-        spirv: inline_spirv!(
-            r#"#version 450
-            layout(location = 0) out vec4 outColor;
-            void main() {
-                outColor = vec4(1.0); // White lighting for now
-            }"#,
+        spirv: include_spirv!(
+            "shaders/lighting.frag",
             frag
         ),
         specialization: &[],


### PR DESCRIPTION
## Summary
- add `shaders/` folder with GLSL sources
- load shader files in tests/examples using `include_spirv!`
- note shader folder in code comments

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843462ad7ac832a914de3ad13b51150