### PR TITLE
Fix outdated comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// src/render_pass_wrapper.rs
+// Render pass utilities and core modules
 pub mod material;
 pub mod utils;
 pub mod renderer;


### PR DESCRIPTION
## Summary
- update the comment in `src/lib.rs` to describe the module contents

## Testing
- `cargo test --all --quiet` *(fails: cannot find macro `include_spirv` in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684380379a88832a84c529d09856b32e