### PR TITLE
Remove unused renderer tests

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,7 +1,6 @@
 mod drawable;
 pub use drawable::*;
 
-mod tests;
 use crate::material::{PSOBindGroupResources, PSO};
 use crate::utils::ResourceManager;
 use crate::*;


### PR DESCRIPTION
## Summary
- remove empty `tests.rs` from renderer
- drop `mod tests;` reference from `src/renderer/mod.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843a17ad444832a91babf0e4026ba5f