### PR TITLE
Centralize descriptor type mapping

### DIFF
--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -11,16 +11,6 @@ pub use bindless::*;
 pub use bindless_lighting::*;
 use crate::utils::ResourceManager;
 
-fn descriptor_type_to_dashi_local(ty: ShaderDescriptorType) -> BindGroupVariableType {
-    match ty {
-        ShaderDescriptorType::SampledImage | ShaderDescriptorType::CombinedImageSampler => BindGroupVariableType::SampledImage,
-        ShaderDescriptorType::UniformBuffer => BindGroupVariableType::Uniform,
-        ShaderDescriptorType::StorageBuffer => BindGroupVariableType::Storage,
-        ShaderDescriptorType::StorageImage => BindGroupVariableType::StorageImage,
-        other => panic!("Unsupported descriptor type: {:?}", other),
-    }
-}
-
 pub struct MaterialPipeline {
     pub name: String,
     pub pipeline: Handle<GraphicsPipeline>,
@@ -117,7 +107,7 @@ impl MaterialPipeline {
             for b in binds {
                 bind_map.insert(b.name.clone(), b.binding);
                 vars.push(BindGroupVariable {
-                    var_type: descriptor_type_to_dashi_local(b.ty),
+                    var_type: descriptor_to_var_type(b.ty),
                     binding: b.binding,
                     count: b.count,
                 });

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -9,19 +9,6 @@ use spirv_reflect::ShaderModule;
 
 use self::shader_reflection::*;
 
-/// Map shader descriptor types to Dashi bind group variable types
-fn descriptor_type_to_dashi(ty: ShaderDescriptorType) -> BindGroupVariableType {
-    match ty {
-        ShaderDescriptorType::SampledImage | ShaderDescriptorType::CombinedImageSampler => {
-            BindGroupVariableType::SampledImage
-        }
-        ShaderDescriptorType::UniformBuffer => BindGroupVariableType::Uniform,
-        ShaderDescriptorType::StorageBuffer => BindGroupVariableType::Storage,
-        ShaderDescriptorType::StorageImage => BindGroupVariableType::StorageImage,
-        other => panic!("Unsupported descriptor type: {:?}", other),
-    }
-}
-
 /// Map SPIR-V reflect format to shader primitive enum
 fn reflect_format_to_shader_primitive(fmt: ReflectFormat) -> ShaderPrimitiveType {
     use ReflectFormat::*;
@@ -378,7 +365,7 @@ impl<'a> PipelineBuilder<'a> {
             let mut vars = Vec::new();
 
             for b in binds.iter() {
-                let var_type = descriptor_type_to_dashi(b.ty);
+                let var_type = descriptor_to_var_type(b.ty);
                 vars.push(BindGroupVariable {
                     var_type,
                     binding: b.binding,
@@ -593,11 +580,11 @@ mod tests {
     #[serial]
     fn descriptor_mapping_roundtrip() {
         assert_eq!(
-            descriptor_type_to_dashi(ShaderDescriptorType::SampledImage),
+            descriptor_to_var_type(ShaderDescriptorType::SampledImage),
             BindGroupVariableType::SampledImage
         );
         assert_eq!(
-            descriptor_type_to_dashi(ShaderDescriptorType::UniformBuffer),
+            descriptor_to_var_type(ShaderDescriptorType::UniformBuffer),
             BindGroupVariableType::Uniform
         );
     }

--- a/src/material/shader_reflection.rs
+++ b/src/material/shader_reflection.rs
@@ -148,3 +148,16 @@ fn descriptor_type_to_string(ty: ReflectDescriptorType) -> String {
         _ => format!("unknown({:?})", ty),
     }
 }
+
+/// Map a [`ShaderDescriptorType`] to the corresponding [`BindGroupVariableType`].
+pub fn descriptor_to_var_type(ty: ShaderDescriptorType) -> BindGroupVariableType {
+    match ty {
+        ShaderDescriptorType::SampledImage | ShaderDescriptorType::CombinedImageSampler => {
+            BindGroupVariableType::SampledImage
+        }
+        ShaderDescriptorType::UniformBuffer => BindGroupVariableType::Uniform,
+        ShaderDescriptorType::StorageBuffer => BindGroupVariableType::Storage,
+        ShaderDescriptorType::StorageImage => BindGroupVariableType::StorageImage,
+        other => panic!("Unsupported descriptor type: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- add `descriptor_to_var_type` helper in shader reflection
- use the new helper in `mod.rs` and `pipeline_builder.rs`
- remove old mapping functions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843a1772d24832a83c4b31cbbfadc83