### PR TITLE
Fix unused variable warnings

### DIFF
--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -22,7 +22,7 @@ pub struct MaterialPipeline {
 impl MaterialPipeline {
     pub fn from_yaml(
         ctx: &mut Context,
-        res: &mut ResourceManager,
+        _res: &mut ResourceManager,
         yaml: &serde_yaml::Mapping,
         render_pass: Handle<RenderPass>,
         subpass_id: u32,

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -287,7 +287,7 @@ impl RenderPassBuilder {
             });
         }
         let mut all_colors = Vec::new();
-        let mut depth_attachment = None;
+        let mut _depth_attachment = None;
 
         for (name, att) in &name_to_render_attachment {
             if self
@@ -295,7 +295,7 @@ impl RenderPassBuilder {
                 .iter()
                 .any(|sp| sp.depth_stencil_attachment.as_ref() == Some(name))
             {
-                depth_attachment = Some(att.clone());
+                _depth_attachment = Some(att.clone());
             } else {
                 all_colors.push(att.clone());
             }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -42,7 +42,7 @@ impl Renderer {
        unsafe{&mut *self.ctx}
     }
 
-    pub fn new(width: u32, height: u32, title: &str, ctx: &mut Context) -> Result<Self, GPUError> {
+    pub fn new(width: u32, height: u32, _title: &str, ctx: &mut Context) -> Result<Self, GPUError> {
         let clear_color = [0.1, 0.2, 0.3, 1.0];
 
         let ptr: *mut Context =  ctx;
@@ -181,8 +181,8 @@ impl Renderer {
                         .collect::<Vec<_>>(),
                 })
                 .unwrap();
-                let (pso, bind_groups) = &self.pipelines[&RenderStage::Opaque];
-                for (idx, (mesh, dynamic_buffers)) in self.drawables.iter().enumerate() {
+                let (_pso, bind_groups) = &self.pipelines[&RenderStage::Opaque];
+                for (_idx, (mesh, _dynamic_buffers)) in self.drawables.iter().enumerate() {
                     let vb = mesh.vertex_buffer.expect("Vertex buffer missing");
                     let ib = mesh.index_buffer;
                     let draw: dashi::Command = if let Some(ib) = ib {

--- a/src/utils/allocator.rs
+++ b/src/utils/allocator.rs
@@ -82,19 +82,19 @@ impl GpuAllocator {
     pub fn allocate(&mut self, size: u64) -> Option<Allocation> {
         // First, try from free list
         let aligned_size = Self::align_up(size, self.alignment);
-        if let Some((index, (offset, free_size))) = self
+        if let Some((index, (_offset, free_size))) = self
             .free_list
             .iter()
             .enumerate()
-            .find(|(_, (offset, free_size))| *free_size >= aligned_size)
+            .find(|(_, (_offset, free_size))| *free_size >= aligned_size)
         {
             let alloc = Allocation {
                 buffer: self.buffer,
-                offset: *offset,
+                offset: *_offset,
                 size: aligned_size,
             };
             if *free_size > aligned_size {
-                self.free_list[index] = (offset + aligned_size, free_size - aligned_size);
+                self.free_list[index] = (_offset + aligned_size, free_size - aligned_size);
             } else {
                 self.free_list.swap_remove(index);
             }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -39,7 +39,7 @@ impl DHObject {
         };
         slice[..bytes.len()].copy_from_slice(bytes);
 
-        ctx.unmap_buffer(alloc.buffer);
+        let _ = ctx.unmap_buffer(alloc.buffer);
         Ok(Self {
             handle: alloc.buffer,
             offset: alloc.offset,

--- a/test/sample/bin.rs
+++ b/test/sample/bin.rs
@@ -117,7 +117,7 @@ pub fn render_sample_model(ctx: &mut Context, rp: Handle<RenderPass>, targets: &
             }
         }
 
-        let (img, acquire_sem, img_idx, _ok) = ctx.acquire_new_image(&mut display).unwrap();
+        let (img, acquire_sem, _img_idx, _ok) = ctx.acquire_new_image(&mut display).unwrap();
 
         framed_list.record(|list| {
             for target in targets {

--- a/test/sample_deferred/bin.rs
+++ b/test/sample_deferred/bin.rs
@@ -149,7 +149,7 @@ pub fn run(ctx: &mut Context) {
     let semaphores = ctx.make_semaphores(2).unwrap();
     let mut framed = FramedCommandList::new(ctx, "deferred", 2);
     let mut event_pump = ctx.get_sdl_ctx().event_pump().unwrap();
-    let mut timer = Instant::now();
+    let _timer = Instant::now();
 
     'main: loop {
         for e in event_pump.poll_iter() {

--- a/test/sample_shadows/bin.rs
+++ b/test/sample_shadows/bin.rs
@@ -258,7 +258,7 @@ pub fn run(ctx: &mut Context) {
         ),
         specialization: &[],
     };
-    let vertex_info = VertexDescriptionInfo {
+    let _vertex_info = VertexDescriptionInfo {
         entries: &[VertexEntryInfo {
             format: ShaderPrimitiveType::Vec3,
             location: 0,


### PR DESCRIPTION
## Summary
- silence unused variable warnings by prefixing variables with `_`
- update sample programs accordingly

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843b1aa6c7c832aa866ecca5edd0c99