### PR TITLE
Fix CI test failure propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
           profile: minimal
           cache: true
       - name: Run tests
-        run: cargo test --all --locked | tee test-results.txt
+        run: |
+          set -euo pipefail
+          cargo test --all --locked | tee test-results.txt
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- ensure the CI job fails when `cargo test` fails by enabling `pipefail`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843b462a770832a92b8960318c02002