### PR TITLE
Add llvmpipe ICD configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -17,6 +19,10 @@ jobs:
           override: true
           profile: minimal
           cache: true
+      - name: Install llvmpipe Vulkan driver
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers
       - name: Run tests
         run: cargo test --all --locked | tee test-results.txt
       - name: Upload test results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -16,6 +18,11 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+
+      - name: Install llvmpipe Vulkan driver
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers
 
       - name: Build
         run: cargo build --release


### PR DESCRIPTION
## Summary
- use llvmpipe Vulkan ICD for CI jobs
- use llvmpipe Vulkan ICD for release job
- install Mesa Vulkan drivers so llvmpipe ICD is present

## Testing
- `cargo test --all --locked`


------
https://chatgpt.com/codex/tasks/task_e_6843b44ba170832aab072edfb65bec8c