### PR TITLE
Fix warnings from cargo test

### DIFF
--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -22,12 +22,11 @@ pub struct MaterialPipeline {
 impl MaterialPipeline {
     pub fn from_yaml(
         ctx: &mut Context,
-        res: &mut ResourceManager,
+        _res: &mut ResourceManager,
         yaml: &serde_yaml::Mapping,
         render_pass: Handle<RenderPass>,
         subpass_id: u32,
     ) -> Result<Self, GPUError> {
-        use ShaderType::*;
         pub struct OwnedPipelineShaderInfo {
             pub stage: ShaderType,
             pub spirv: Vec<u32>,

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -1,7 +1,6 @@
 use crate::material::*;
-use crate::utils::{DHObject, ResourceBinding, ResourceBuffer, Texture};
+use crate::utils::{ResourceBinding, Texture};
 use bytemuck::Pod;
-use dashi::*;
 use std::collections::HashMap;
 
 use spirv_reflect::types::ReflectFormat;
@@ -24,8 +23,6 @@ pub struct ShaderVariable {
     allocation: crate::utils::DHObject,
     members: Vec<(String, u32, u32)>,
     ctx: *mut Context,
-    set: usize,
-    binding: u32,
 }
 
 impl ShaderVariable {
@@ -39,7 +36,7 @@ impl ShaderVariable {
             .expect("Field not found");
         assert!(std::mem::size_of::<T>() <= *size as usize, "Size mismatch");
 
-        let slice = unsafe { ctx.map_buffer_mut(self.allocation.handle).unwrap() };
+        let slice = ctx.map_buffer_mut(self.allocation.handle).unwrap();
         let bytes = bytemuck::bytes_of(&value);
         slice[(self.allocation.offset + *offset as u64) as usize..][..bytes.len()]
             .copy_from_slice(bytes);
@@ -55,7 +52,7 @@ impl ShaderVariable {
             "Size mismatch"
         );
 
-        let slice = unsafe { ctx.map_buffer_mut(self.allocation.handle).unwrap() };
+        let slice = ctx.map_buffer_mut(self.allocation.handle).unwrap();
         let bytes = bytemuck::bytes_of(&value);
         slice[self.allocation.offset as usize..][..bytes.len()].copy_from_slice(bytes);
 
@@ -71,7 +68,7 @@ impl ShaderVariable {
             .expect("Field not found");
         assert!(std::mem::size_of::<T>() <= *size as usize, "Size mismatch");
 
-        let slice = unsafe { ctx.map_buffer::<u8>(self.allocation.handle).unwrap() };
+        let slice = ctx.map_buffer::<u8>(self.allocation.handle).unwrap();
         let data_slice = &slice[(self.allocation.offset + *offset as u64) as usize..];
         let value = bytemuck::from_bytes::<T>(&data_slice[..std::mem::size_of::<T>()]);
 
@@ -87,7 +84,7 @@ impl ShaderVariable {
             "Size mismatch"
         );
 
-        let slice = unsafe { ctx.map_buffer::<u8>(self.allocation.handle).unwrap() };
+        let slice = ctx.map_buffer::<u8>(self.allocation.handle).unwrap();
         let data_slice = &slice[self.allocation.offset as usize..];
         let value = bytemuck::from_bytes::<T>(&data_slice[..std::mem::size_of::<T>()]);
 
@@ -402,7 +399,6 @@ impl<'a> PipelineBuilder<'a> {
                 ShaderPrimitiveType::Vec4 | ShaderPrimitiveType::IVec4 => 16,
                 ShaderPrimitiveType::Vec3 => 12,
                 ShaderPrimitiveType::Vec2 => 8,
-                _ => 0,
             };
         }
 
@@ -481,7 +477,7 @@ mod tests {
         material::pipeline_builder::ShaderDescriptorType,
         utils::{
             allocator::GpuAllocator, resource_list::ResourceList, CombinedTextureSampler,
-            TextureInfo,
+            DHObject, ResourceBuffer,
         },
     };
     use dashi::builders::RenderPassBuilder;
@@ -491,28 +487,6 @@ mod tests {
 
     fn make_ctx() -> Context {
         Context::headless(&ContextInfo::default()).unwrap()
-    }
-    fn simple_vert() -> Vec<u32> {
-        inline_spirv!(
-            r#"
-            #version 450
-            layout(set=0,binding=0) uniform U{vec4 u;};
-            layout(location=0) in vec2 v;
-            void main(){ gl_Position=vec4(v,0,1); }"#,
-            vert
-        )
-        .to_vec()
-    }
-    fn simple_frag() -> Vec<u32> {
-        inline_spirv!(
-            r#"
-            #version 450
-            layout(set=0,binding=1) uniform U2{float x;};
-            layout(location=0) out vec4 o;
-            void main(){ o=vec4(x); }"#,
-            frag
-        )
-        .to_vec()
     }
 
     fn simple_vertex_spirv() -> Vec<u32> {
@@ -657,8 +631,6 @@ mod tests {
             allocation,
             members: vec![("data".into(), 0, 4)],
             ctx: &mut ctx,
-            set: 0,
-            binding: 0,
         };
 
         variable.write(100u32);
@@ -684,8 +656,6 @@ mod tests {
             },
             members: vec![],
             ctx: std::ptr::null_mut(),
-            set: 0,
-            binding: 0,
         };
 
         let mut resource = PSOResource {

--- a/src/material/shader_reflection.rs
+++ b/src/material/shader_reflection.rs
@@ -1,8 +1,7 @@
 use crate::material::*;
-use dashi::*;
-use spirv_reflect::types::{ReflectDescriptorType, ReflectTypeDescription};
+use spirv_reflect::types::ReflectDescriptorType;
 use spirv_reflect::ShaderModule;
-use std::{collections::HashMap, fs};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ShaderDescriptorType {
@@ -130,24 +129,6 @@ fn map_descriptor_type(ty: ReflectDescriptorType) -> ShaderDescriptorType {
     }
 }
 
-fn descriptor_type_to_string(ty: ReflectDescriptorType) -> String {
-    use ReflectDescriptorType::*;
-    match ty {
-        Sampler => "sampler".to_string(),
-        CombinedImageSampler => "combined_image_sampler".to_string(),
-        SampledImage => "sampled_image".to_string(),
-        StorageImage => "storage_image".to_string(),
-        UniformTexelBuffer => "uniform_texel_buffer".to_string(),
-        StorageTexelBuffer => "storage_texel_buffer".to_string(),
-        UniformBuffer => "uniform_buffer".to_string(),
-        StorageBuffer => "storage_buffer".to_string(),
-        UniformBufferDynamic => "uniform_buffer_dynamic".to_string(),
-        StorageBufferDynamic => "storage_buffer_dynamic".to_string(),
-        InputAttachment => "input_attachment".to_string(),
-        AccelerationStructureKHR => "acceleration_structure_khr".to_string(),
-        _ => format!("unknown({:?})", ty),
-    }
-}
 
 /// Map a [`ShaderDescriptorType`] to the corresponding [`BindGroupVariableType`].
 pub fn descriptor_to_var_type(ty: ShaderDescriptorType) -> BindGroupVariableType {

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -287,7 +287,7 @@ impl RenderPassBuilder {
             });
         }
         let mut all_colors = Vec::new();
-        let mut depth_attachment = None;
+        let mut _depth_attachment = None;
 
         for (name, att) in &name_to_render_attachment {
             if self
@@ -295,7 +295,7 @@ impl RenderPassBuilder {
                 .iter()
                 .any(|sp| sp.depth_stencil_attachment.as_ref() == Some(name))
             {
-                depth_attachment = Some(att.clone());
+                _depth_attachment = Some(att.clone());
             } else {
                 all_colors.push(att.clone());
             }
@@ -394,7 +394,7 @@ mod tests {
             .depth_attachment("depth", Format::D24S8)
             .subpass("main", ["color"], &[] as &[&str]);
 
-        let (_, targets, all) = builder.build_with_images(&mut ctx).unwrap();
+        let (_, targets, _all) = builder.build_with_images(&mut ctx).unwrap();
         assert!(!targets.is_empty());
         assert_eq!(targets[0].colors.len(), 1);
         assert!(targets[0].depth.is_some());

--- a/src/renderer/drawable.rs
+++ b/src/renderer/drawable.rs
@@ -1,6 +1,5 @@
 //! Types of drawables that can be registered with the renderer.
 //! These may expand to support more mesh/material types and instancing.
-use dashi::*;
 use dashi::{utils::Handle, *};
 use glam::Mat4;
 use crate::animation::Skeleton;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -42,7 +42,7 @@ impl Renderer {
        unsafe{&mut *self.ctx}
     }
 
-    pub fn new(width: u32, height: u32, title: &str, ctx: &mut Context) -> Result<Self, GPUError> {
+    pub fn new(width: u32, height: u32, _title: &str, ctx: &mut Context) -> Result<Self, GPUError> {
         let clear_color = [0.1, 0.2, 0.3, 1.0];
 
         let ptr: *mut Context =  ctx;
@@ -181,8 +181,8 @@ impl Renderer {
                         .collect::<Vec<_>>(),
                 })
                 .unwrap();
-                let (pso, bind_groups) = &self.pipelines[&RenderStage::Opaque];
-                for (idx, (mesh, dynamic_buffers)) in self.drawables.iter().enumerate() {
+                let (_pso, bind_groups) = &self.pipelines[&RenderStage::Opaque];
+                for (_idx, (mesh, _dynamic_buffers)) in self.drawables.iter().enumerate() {
                     let vb = mesh.vertex_buffer.expect("Vertex buffer missing");
                     let ib = mesh.index_buffer;
                     let draw: dashi::Command = if let Some(ib) = ib {

--- a/src/utils/allocator.rs
+++ b/src/utils/allocator.rs
@@ -86,7 +86,7 @@ impl GpuAllocator {
             .free_list
             .iter()
             .enumerate()
-            .find(|(_, (offset, free_size))| *free_size >= aligned_size)
+            .find(|(_, (_offset, free_size))| *free_size >= aligned_size)
         {
             let alloc = Allocation {
                 buffer: self.buffer,
@@ -167,7 +167,7 @@ mod test {
         let mut alloc = GpuAllocator::new(&mut ctx, 1024, BufferUsage::STORAGE, 64).unwrap();
 
         let a = alloc.allocate(128).unwrap();
-        let b = alloc.allocate(128).unwrap();
+        let _b = alloc.allocate(128).unwrap();
         let ao = a.offset;
         alloc.free(a);
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use bytemuck::NoUninit;
 use dashi::*;
 use utils::Handle;
 
@@ -39,7 +38,7 @@ impl DHObject {
         };
         slice[..bytes.len()].copy_from_slice(bytes);
 
-        ctx.unmap_buffer(alloc.buffer);
+        let _ = ctx.unmap_buffer(alloc.buffer);
         Ok(Self {
             handle: alloc.buffer,
             offset: alloc.offset,

--- a/test/sample/bin.rs
+++ b/test/sample/bin.rs
@@ -1,9 +1,7 @@
 use dashi::utils::*;
 use dashi::*;
 use koji::*;
-use koji::render_pass::*;
 use sdl2::{event::Event, keyboard::Keycode};
-use std::sync::Arc;
 // Shaders are stored under `shaders/` and compiled at build time using `include_spirv!`.
 
 pub fn main() {
@@ -117,7 +115,7 @@ pub fn render_sample_model(ctx: &mut Context, rp: Handle<RenderPass>, targets: &
             }
         }
 
-        let (img, acquire_sem, img_idx, _ok) = ctx.acquire_new_image(&mut display).unwrap();
+        let (img, acquire_sem, _img_idx, _ok) = ctx.acquire_new_image(&mut display).unwrap();
 
         framed_list.record(|list| {
             for target in targets {

--- a/test/sample_deferred/bin.rs
+++ b/test/sample_deferred/bin.rs
@@ -1,9 +1,7 @@
 // src/deferred_render.rs
-use dashi::utils::*;
 use dashi::*;
 use inline_spirv::include_spirv;
 use koji::render_pass::*;
-use koji::*;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 // Shader sources live in `shaders/` and are included with `include_spirv!`.
@@ -149,7 +147,7 @@ pub fn run(ctx: &mut Context) {
     let semaphores = ctx.make_semaphores(2).unwrap();
     let mut framed = FramedCommandList::new(ctx, "deferred", 2);
     let mut event_pump = ctx.get_sdl_ctx().event_pump().unwrap();
-    let mut timer = Instant::now();
+    let _timer = Instant::now();
 
     'main: loop {
         for e in event_pump.poll_iter() {

--- a/test/sample_shadows/bin.rs
+++ b/test/sample_shadows/bin.rs
@@ -1,15 +1,10 @@
-use bytemuck::*;
-use dashi::utils::*;
 use dashi::*;
 use glam::*;
 use inline_spirv::include_spirv;
 use koji::render_pass::*;
-use koji::*;
 use sdl2::keyboard::Keycode;
 use sdl2::event::Event;
 // Shader code is located in `shaders/` and included via `include_spirv!`.
-use std::f32::consts::PI;
-use std::time::Instant;
 
 pub fn run(ctx: &mut Context) {
     const WIDTH: u32 = 640;
@@ -258,7 +253,7 @@ pub fn run(ctx: &mut Context) {
         ),
         specialization: &[],
     };
-    let vertex_info = VertexDescriptionInfo {
+    let _vertex_info = VertexDescriptionInfo {
         entries: &[VertexEntryInfo {
             format: ShaderPrimitiveType::Vec3,
             location: 0,

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -1,6 +1,5 @@
 use koji::material::*;
 use koji::renderer::*;
-use koji::utils::*;
 use dashi::*;
 use serial_test::serial;
 use inline_spirv::include_spirv;

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -1,9 +1,7 @@
-use koji::*;
 use koji::material::*;
 use koji::renderer::*;
-use koji::utils::*;
 use dashi::*;
-use bytemuck::{Pod, Zeroable};
+
 use inline_spirv::include_spirv;
 use serial_test::serial;
 // External shader files are loaded from `shaders/` using `include_spirv!`.


### PR DESCRIPTION
## Summary
- remove unused imports and functions
- drop unused struct fields
- clean up unsafe blocks and unreachable match
- ignore unused results
- prefix unused variables with underscores
- fix tests and examples

## Testing
- `cargo check --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6843b2bb8290832aaf456bee60b968a8