### PR TITLE
Implement skeletal mesh bone updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,9 @@ name = "glam"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "gltf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 
 [dependencies]
-glam = "0.29.0" 
+glam = { version = "0.29.0", features = ["bytemuck"] }
 rhai = {git = "https://github.com/rhaiscript/rhai" }
 dashi = {git = "https://github.com/JordanHendl/dashi", features = ["dashi-serde"]}
 #dashi = {path = "C:/Program Files/Git/wksp/git/dashi", features = ["dashi-serde"]}


### PR DESCRIPTION
## Summary
- support uploading bone matrices with `SkeletalMesh::update_bones`
- add `Renderer` helpers to register skeletal meshes and update their bones
- enable bytemuck support for `glam` to allow direct casts

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843bc80b238832a93129a8af15aa2d7