### PR TITLE
Fix animator hierarchy update

### DIFF
--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -31,19 +31,36 @@ impl Animator {
 
     pub fn update(&mut self, local: &[Mat4]) {
         assert_eq!(local.len(), self.skeleton.bone_count());
-        for (i, bone) in self.skeleton.bones.iter().enumerate() {
-            let parent_world = bone
-                .parent
-                .and_then(|p| self.matrices.get(p).cloned())
-                .unwrap_or(Mat4::IDENTITY);
-            let world = parent_world * local[i];
-            self.matrices[i] = world * bone.inverse_bind;
+        let mut world_cache: Vec<Option<Mat4>> = vec![None; self.skeleton.bone_count()];
+        for i in 0..self.skeleton.bone_count() {
+            let world = compute_world_recursive(&self.skeleton, i, local, &mut world_cache);
+            self.matrices[i] = world * self.skeleton.bones[i].inverse_bind;
         }
     }
 
     pub fn matrices(&self) -> &[Mat4] {
         &self.matrices
     }
+}
+
+fn compute_world_recursive(
+    skeleton: &Skeleton,
+    index: usize,
+    local: &[Mat4],
+    cache: &mut [Option<Mat4>],
+) -> Mat4 {
+    if let Some(m) = cache[index] {
+        return m;
+    }
+    let bone = &skeleton.bones[index];
+    let parent_world = if let Some(p) = bone.parent {
+        compute_world_recursive(skeleton, p, local, cache)
+    } else {
+        Mat4::IDENTITY
+    };
+    let world = parent_world * local[index];
+    cache[index] = Some(world);
+    world
 }
 
 #[cfg(test)]
@@ -75,6 +92,34 @@ mod tests {
         let mats = animator.matrices();
         let root_pos = mats[0].transform_point3(Vec3::ZERO);
         let child_pos = mats[1].transform_point3(Vec3::ZERO);
+        assert_eq!(root_pos, Vec3::new(1.0, 0.0, 0.0));
+        assert_eq!(child_pos, Vec3::new(1.0, 0.0, 1.0));
+    }
+
+    #[test]
+    fn out_of_order_bones() {
+        let bones = vec![
+            Bone {
+                name: "child".into(),
+                parent: Some(1),
+                inverse_bind: Mat4::IDENTITY,
+            },
+            Bone {
+                name: "root".into(),
+                parent: None,
+                inverse_bind: Mat4::IDENTITY,
+            },
+        ];
+        let skeleton = Skeleton { bones };
+        let mut animator = Animator::new(skeleton);
+        let local = vec![
+            Mat4::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+            Mat4::from_translation(Vec3::new(1.0, 0.0, 0.0)),
+        ];
+        animator.update(&local);
+        let mats = animator.matrices();
+        let root_pos = mats[1].transform_point3(Vec3::ZERO);
+        let child_pos = mats[0].transform_point3(Vec3::ZERO);
         assert_eq!(root_pos, Vec3::new(1.0, 0.0, 0.0));
         assert_eq!(child_pos, Vec3::new(1.0, 0.0, 1.0));
     }


### PR DESCRIPTION
## Summary
- compute bone transforms recursively
- add test covering out-of-order bones

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843bc856668832ab94c761691d7cde1