### PR TITLE
Add skeletal mesh pipeline support

### DIFF
--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -4,6 +4,7 @@ pub mod shader_reflection;
 pub mod pipeline_builder;
 pub mod bindless;
 pub mod bindless_lighting;
+pub mod skinning;
 
 #[cfg(test)]
 mod pipeline_builder_tests;
@@ -12,6 +13,7 @@ pub use pipeline_builder::*;
 pub use shader_reflection::*;
 pub use bindless::*;
 pub use bindless_lighting::*;
+pub use skinning::*;
 use crate::utils::ResourceManager;
 
 pub struct MaterialPipeline {

--- a/src/material/skinning.rs
+++ b/src/material/skinning.rs
@@ -1,0 +1,30 @@
+use crate::material::pipeline_builder::PipelineBuilder;
+use crate::material::PSO;
+use dashi::{gpu::RenderPass, Context, utils::Handle};
+
+/// Build a simple pipeline for rendering [`SkeletalMesh`] objects.
+///
+/// The vertex shader performs linear blend skinning and outputs vertex color.
+/// A minimal fragment shader simply passes this color through.
+pub fn build_skinning_pipeline(
+    ctx: &mut Context,
+    rp: Handle<RenderPass>,
+    subpass: u32,
+) -> PSO {
+    let vert: &[u32] = inline_spirv::include_spirv!(
+        "src/renderer/skinning.vert",
+        vert,
+        glsl
+    );
+    let frag: &[u32] = inline_spirv::include_spirv!(
+        "shaders/test_triangle.frag",
+        frag,
+        glsl
+    );
+    PipelineBuilder::new(ctx, "skinning_pipeline")
+        .vertex_shader(vert)
+        .fragment_shader(frag)
+        .render_pass(rp, subpass)
+        .build()
+}
+

--- a/tests/skinning.rs
+++ b/tests/skinning.rs
@@ -1,0 +1,64 @@
+use koji::material::*;
+use koji::renderer::*;
+use koji::animation::*;
+use dashi::*;
+use glam::Mat4;
+use serial_test::serial;
+
+fn make_vertex(pos:[f32;3], col:[f32;4]) -> SkeletalVertex {
+    SkeletalVertex {
+        position: pos,
+        normal: [0.0,0.0,1.0],
+        tangent: [1.0,0.0,0.0,1.0],
+        uv: [0.0,0.0],
+        color: col,
+        joint_indices: [0,0,0,0],
+        joint_weights: [1.0,0.0,0.0,0.0],
+    }
+}
+
+fn simple_mesh() -> SkeletalMesh {
+    let verts = vec![
+        make_vertex([0.0,-0.5,0.0],[1.0,0.0,0.0,1.0]),
+        make_vertex([0.5,0.5,0.0],[0.0,1.0,0.0,1.0]),
+        make_vertex([-0.5,0.5,0.0],[0.0,0.0,1.0,1.0]),
+    ];
+    SkeletalMesh {
+        vertices: verts,
+        indices: None,
+        vertex_buffer: None,
+        index_buffer: None,
+        index_count: 0,
+        skeleton: Skeleton { bones: vec![Bone{ name:"root".into(), parent: None, inverse_bind: Mat4::IDENTITY}] },
+        bone_buffer: None,
+    }
+}
+
+#[test]
+#[serial]
+#[ignore]
+fn render_skeletal_triangle(){
+    let device = DeviceSelector::new().unwrap().select(DeviceFilter::default().add_required_type(DeviceType::Dedicated)).unwrap_or_default();
+    let mut ctx = Context::new(&ContextInfo{ device }).unwrap();
+    let mut renderer = Renderer::new(320,240,"skel", &mut ctx).expect("renderer");
+
+    let mut mesh = simple_mesh();
+    mesh.upload(&mut ctx).unwrap();
+    let bone_buf = mesh.bone_buffer.unwrap();
+    renderer.register_skeletal_mesh(mesh);
+
+    renderer.resources().register_storage("bone_buf", bone_buf);
+    let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
+    let bgr = pso.create_bind_groups(&renderer.resources());
+    renderer.register_pso(RenderStage::Skinned, pso, bgr);
+
+    let slice = unsafe { ctx.map_buffer_mut(bone_buf).unwrap() };
+    let mat = Mat4::IDENTITY.to_cols_array();
+    let bytes = bytemuck::bytes_of(&mat);
+    slice[..bytes.len()].copy_from_slice(bytes);
+    ctx.unmap_buffer(bone_buf).unwrap();
+
+    renderer.present_frame().unwrap();
+    ctx.destroy();
+}
+


### PR DESCRIPTION
## Summary
- add a `skinning` pipeline builder compiling `skinning.vert` and a passthrough fragment shader
- extend `Renderer` with `Skinned` stage and methods to register and render skeletal meshes
- provide a test showing how to render a simple skinned triangle

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843bc86f5c4832aa5e8a438fa4899af