### PR TITLE
Add skeletal mesh pipeline

### DIFF
--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -4,6 +4,7 @@ pub mod shader_reflection;
 pub mod pipeline_builder;
 pub mod bindless;
 pub mod bindless_lighting;
+pub mod skin_pipeline;
 
 #[cfg(test)]
 mod pipeline_builder_tests;
@@ -12,6 +13,7 @@ pub use pipeline_builder::*;
 pub use shader_reflection::*;
 pub use bindless::*;
 pub use bindless_lighting::*;
+pub use skin_pipeline::build_skinning_pipeline;
 use crate::utils::ResourceManager;
 
 pub struct MaterialPipeline {

--- a/src/material/skin_pipeline.rs
+++ b/src/material/skin_pipeline.rs
@@ -1,0 +1,13 @@
+use inline_spirv::include_spirv;
+use dashi::{*, utils::Handle};
+use crate::material::pipeline_builder::PipelineBuilder;
+
+pub fn build_skinning_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> crate::material::PSO {
+    let vert: &[u32] = include_spirv!("src/renderer/skinning.vert", vert, glsl);
+    let frag: &[u32] = include_spirv!("src/renderer/skinning.frag", frag, glsl);
+    PipelineBuilder::new(ctx, "skinning_pipeline")
+        .vertex_shader(vert)
+        .fragment_shader(frag)
+        .render_pass(rp, subpass)
+        .build()
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -29,6 +29,7 @@ pub struct Renderer {
     render_pass: Handle<RenderPass>,
     targets: Vec<RenderTarget>,
     pipelines: HashMap<RenderStage, (PSO, [Option<PSOBindGroupResources>; 4])>,
+    skeletal_pipeline: Option<(PSO, [Option<PSOBindGroupResources>; 4])>,
     resource_manager: ResourceManager,
     lights: BindlessLights,
     drawables: Vec<(StaticMesh, Option<DynamicBuffer>)>,
@@ -92,6 +93,7 @@ impl Renderer {
             render_pass,
             targets,
             pipelines: HashMap::new(),
+            skeletal_pipeline: None,
             drawables: Vec::new(),
             skeletal_meshes: Vec::new(),
             resource_manager,
@@ -120,6 +122,14 @@ impl Renderer {
         self.pipelines.insert(stage, (pso, bind_group_resources));
     }
 
+    pub fn register_skeletal_pso(
+        &mut self,
+        pso: PSO,
+        bind_group_resources: [Option<PSOBindGroupResources>; 4],
+    ) {
+        self.skeletal_pipeline = Some((pso, bind_group_resources));
+    }
+
     pub fn register_static_mesh(
         &mut self,
         mut mesh: StaticMesh,
@@ -135,6 +145,9 @@ impl Renderer {
     pub fn register_skeletal_mesh(&mut self, mut mesh: SkeletalMesh) {
         mesh.upload(self.get_ctx())
             .expect("Failed to upload skeletal mesh to GPU");
+        if let Some(buf) = mesh.bone_buffer {
+            self.resource_manager.register_storage("bone_buf", buf);
+        }
         self.skeletal_meshes.push(mesh);
     }
   
@@ -254,6 +267,66 @@ impl Renderer {
                 }
 
                 list.end_drawing().unwrap();
+
+                if let Some((pso, bind_groups)) = &self.skeletal_pipeline {
+                    list.begin_drawing(&DrawBegin {
+                        viewport: Viewport {
+                            area: FRect2D {
+                                w: self.width as f32,
+                                h: self.height as f32,
+                                ..Default::default()
+                            },
+                            scissor: Rect2D {
+                                w: self.width,
+                                h: self.height,
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        pipeline: pso.pipeline,
+                        attachments: &target
+                            .colors
+                            .iter()
+                            .map(|a| a.attachment)
+                            .collect::<Vec<_>>(),
+                    })
+                    .unwrap();
+                    for mesh in &self.skeletal_meshes {
+                        let vb = mesh.vertex_buffer.expect("Vertex buffer missing");
+                        let ib = mesh.index_buffer;
+                        let draw: dashi::Command = if let Some(ib) = ib {
+                            Command::DrawIndexed(DrawIndexed {
+                                index_count: mesh.index_count as u32,
+                                instance_count: 1,
+                                vertices: vb,
+                                indices: ib,
+                                bind_groups: [
+                                    bind_groups[0].as_ref().map(|bgr| bgr.bind_group),
+                                    bind_groups[1].as_ref().map(|bgr| bgr.bind_group),
+                                    bind_groups[2].as_ref().map(|bgr| bgr.bind_group),
+                                    bind_groups[3].as_ref().map(|bgr| bgr.bind_group),
+                                ],
+                                ..Default::default()
+                            })
+                        } else {
+                            Command::Draw(Draw {
+                                count: mesh.index_count as u32,
+                                instance_count: 1,
+                                vertices: vb,
+                                bind_groups: [
+                                    bind_groups[0].as_ref().map(|bgr| bgr.bind_group),
+                                    bind_groups[1].as_ref().map(|bgr| bgr.bind_group),
+                                    bind_groups[2].as_ref().map(|bgr| bgr.bind_group),
+                                    bind_groups[3].as_ref().map(|bgr| bgr.bind_group),
+                                ],
+                                ..Default::default()
+                            })
+                        };
+                        list.append(draw);
+                    }
+
+                    list.end_drawing().unwrap();
+                }
 
                 list.blit_image(ImageBlit {
                     src: target.colors[0].attachment.img,

--- a/src/renderer/skinning.frag
+++ b/src/renderer/skinning.frag
@@ -1,0 +1,6 @@
+#version 450
+layout(location = 0) in vec4 vColor;
+layout(location = 0) out vec4 outColor;
+void main() {
+    outColor = vColor;
+}

--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -1,0 +1,35 @@
+use koji::renderer::*;
+use koji::gltf::{load_scene, MeshData};
+use koji::material::*;
+use glam::Mat4;
+use dashi::*;
+use serial_test::serial;
+
+#[test]
+#[serial]
+#[ignore]
+fn render_simple_skeleton() {
+    let device = DeviceSelector::new()
+        .unwrap()
+        .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+        .unwrap_or_default();
+    let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+    let mut renderer = Renderer::new(320, 240, "skin", &mut ctx).unwrap();
+
+    let scene = load_scene("tests/data/simple_skin.gltf").expect("load");
+    let mut mesh = match &scene.meshes[0].mesh {
+        MeshData::Skeletal(m) => m.clone(),
+        _ => panic!("expected skeletal mesh"),
+    };
+    let bone_count = mesh.skeleton.bone_count();
+    renderer.register_skeletal_mesh(mesh);
+
+    let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
+    let bgr = pso.create_bind_groups(&renderer.resources());
+    renderer.register_skeletal_pso(pso, bgr);
+
+    let mats = vec![Mat4::IDENTITY; bone_count];
+    renderer.update_skeletal_bones(0, &mats);
+    renderer.present_frame().unwrap();
+    ctx.destroy();
+}


### PR DESCRIPTION
## Summary
- compile a simple color output fragment shader for `skinning.vert`
- expose `build_skinning_pipeline` helper
- track and draw skeletal meshes with a registered pipeline
- add an ignored test demonstrating skeletal rendering

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843cbe82ebc832ab0a996918d3e0505