### PR TITLE
Handle missing bind group resources gracefully

### DIFF
--- a/src/material/bindless_lighting.rs
+++ b/src/material/bindless_lighting.rs
@@ -158,7 +158,7 @@ mod tests {
         // register the accompanying uniform under an empty key as well.
         res.register_variable("", &mut ctx, count);
 
-        let group = pso.create_bind_group(0, &res);
+        let group = pso.create_bind_group(0, &res).unwrap();
         assert!(group.bind_group.valid());
         assert_eq!(count, 1000);
         res.destroy(&mut ctx);

--- a/src/material/pipeline_builder_tests.rs
+++ b/src/material/pipeline_builder_tests.rs
@@ -259,7 +259,7 @@ fn pipeline_builder_and_bind_group() {
 
     resources.register_combined("tex", img, view, [1, 1], sampler);
 
-    let group = pso.create_bind_group(0, &resources);
+    let group = pso.create_bind_group(0, &resources).unwrap();
 
     assert!(group.bind_group.valid());
     assert!(group.buffers.contains_key("b0"));
@@ -336,7 +336,7 @@ fn bindless_texture_array_in_shader() {
     resources.register_combined_texture_array("bindless_textures", tex_array.clone());
 
     // The pipeline should reflect the unsized array and request the bindless resource
-    let group = pso.create_bind_group(0, &resources);
+    let group = pso.create_bind_group(0, &resources).unwrap();
 
     // Expect a valid bind group, and that "bindless_textures" is registered as a texture array
     assert!(group.bind_group.valid());
@@ -421,7 +421,7 @@ fn multiple_bindless_bindings_in_shader() {
     resources.register_combined_texture_array("tex_array", Arc::new(combined_array));
     resources.register_buffer_array("buf_array", Arc::new(Mutex::new(buf_array)));
 
-    let group = pso.create_bind_group(0, &resources);
+    let group = pso.create_bind_group(0, &resources).unwrap();
 
     assert!(group.bind_group.valid());
     assert!(matches!(

--- a/test/sample/bin.rs
+++ b/test/sample/bin.rs
@@ -95,7 +95,7 @@ pub fn render_sample_model(ctx: &mut Context, rp: Handle<RenderPass>, targets: &
     resources.register_combined("tex", img, view, [1, 1], sampler);
     resources.register_variable("ubo", ctx, uniform_value);
 
-    let bind_group = pso.create_bind_group(0, &resources);
+    let bind_group = pso.create_bind_group(0, &resources).unwrap();
 
     // ==== The rest: draw with pipeline ====
     let mut display = ctx.make_display(&Default::default()).unwrap();

--- a/test/sample_deferred/bin.rs
+++ b/test/sample_deferred/bin.rs
@@ -132,7 +132,7 @@ pub fn run(ctx: &mut Context) {
     lights.register(&mut resources);
     resources.register_variable("", ctx, light_count);
 
-    let lighting_bg = pso_lighting.create_bind_group(0, &resources);
+    let lighting_bg = pso_lighting.create_bind_group(0, &resources).unwrap();
 
     let mut display = ctx.make_display(&Default::default()).unwrap();
     let semaphores = ctx.make_semaphores(2).unwrap();

--- a/tests/bindless_lighting.rs
+++ b/tests/bindless_lighting.rs
@@ -39,7 +39,7 @@ fn bindless_lighting_sample() {
         .fragment_shader(&frag())
         .render_pass(renderer.render_pass(),0)
         .build();
-    let bgr = pso.create_bind_groups(&renderer.resources());
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Opaque, pso, bgr);
 
     let mut lights = BindlessLights::new();

--- a/tests/bindless_rendering.rs
+++ b/tests/bindless_rendering.rs
@@ -40,7 +40,7 @@ fn bindless_rendering_sample() {
         .fragment_shader(&frag)
         .render_pass(renderer.render_pass(),0)
         .build();
-    let bgr = pso.create_bind_groups(&renderer.resources());
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Opaque, pso, bgr);
 
     let mut bindless = BindlessData::new();

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -47,7 +47,7 @@ fn render_pbr_quad() {
     let mut renderer = Renderer::new(320,240,"pbr", &mut ctx).expect("renderer");
 
     let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(),0);
-    let bgr = pso.create_bind_groups(&renderer.resources());
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Opaque, pso, bgr);
 
     let mesh = StaticMesh {

--- a/tests/pbr_spheres.rs
+++ b/tests/pbr_spheres.rs
@@ -56,7 +56,7 @@ fn pbr_spheres() {
     let mut renderer = Renderer::new(320,240,"pbr_spheres",&mut ctx).unwrap();
 
     let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(),0);
-    let bgr = pso.create_bind_groups(&renderer.resources());
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Opaque,pso,bgr);
 
     let (verts,inds) = make_sphere(8,16);

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -97,7 +97,7 @@ fn render_triangle_and_cube() {
         .build();
 
     // Generate/cached bind group resources for all sets
-    let bind_group_resources = pso.create_bind_groups(&renderer.resources());
+    let bind_group_resources = pso.create_bind_groups(&renderer.resources()).unwrap();
 
     // Register pipeline+resources
     renderer.register_pso(RenderStage::Opaque, pso, bind_group_resources);

--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -25,7 +25,7 @@ fn render_simple_skeleton() {
     renderer.register_skeletal_mesh(mesh);
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
-    let bgr = pso.create_bind_groups(&renderer.resources());
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso, bgr);
 
     let mats = vec![Mat4::IDENTITY; bone_count];

--- a/tests/skinned_mesh_render.rs
+++ b/tests/skinned_mesh_render.rs
@@ -21,7 +21,7 @@ fn skinned_mesh_render() {
     renderer.register_skeletal_mesh(mesh);
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(),0);
-    let bgr = pso.create_bind_groups(&renderer.resources());
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso,bgr);
 
     let mats = vec![Mat4::IDENTITY; bone_count];

--- a/tests/static_movement.rs
+++ b/tests/static_movement.rs
@@ -41,7 +41,7 @@ fn static_mesh_with_movement() {
         .fragment_shader(&frag())
         .render_pass(renderer.render_pass(),0)
         .build();
-    let bgr = pso.create_bind_groups(&renderer.resources());
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Opaque,pso,bgr);
 
     let mut mesh = StaticMesh {

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -29,7 +29,7 @@ fn draw_text_2d() {
         .fragment_shader(&frag_spv)
         .render_pass(renderer.render_pass(), 0)
         .build();
-    let bgr = pso.create_bind_groups(renderer.resources());
+    let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Text, pso, bgr);
 
     let font_bytes: &[u8] = include_bytes!("data/DejaVuSans.ttf");


### PR DESCRIPTION
## Summary
- add `PipelineError` for creating bind groups
- return `Result` from `create_bind_group` and `create_bind_groups`
- update library tests and sample code for new Result API

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684462ec1e10832aabba15a210c9cc9b