### PR TITLE
Fix skeletal bone update method

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -202,9 +202,10 @@ impl Renderer {
 
     /// Update bone matrices for a registered skeletal mesh.
     pub fn update_skeletal_bones(&mut self, idx: usize, matrices: &[Mat4]) {
-        if let Some(mesh) = self.skeletal_meshes.get(idx).cloned() {
+        let ctx = self.get_ctx();
+        if let Some(mesh) = self.skeletal_meshes.get_mut(idx) {
             mesh
-                .update_bones(self.get_ctx(), matrices)
+                .update_bones(ctx, matrices)
                 .expect("Failed to update bone matrices");
         }
     }

--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -33,3 +33,33 @@ fn render_simple_skeleton() {
     renderer.present_frame().unwrap();
     ctx.destroy();
 }
+
+#[test]
+#[serial]
+#[ignore]
+fn update_bones_twice() {
+    let device = DeviceSelector::new()
+        .unwrap()
+        .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+        .unwrap_or_default();
+    let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+    let mut renderer = Renderer::new(320, 240, "skin", &mut ctx).unwrap();
+
+    let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
+    let mesh = match &scene.meshes[0].mesh {
+        MeshData::Skeletal(m) => m.clone(),
+        _ => panic!("expected skeletal mesh"),
+    };
+    let bone_count = mesh.skeleton.bone_count();
+    renderer.register_skeletal_mesh(mesh);
+
+    let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_skeletal_pso(pso, bgr);
+
+    let mats = vec![Mat4::IDENTITY; bone_count];
+    renderer.update_skeletal_bones(0, &mats);
+    renderer.update_skeletal_bones(0, &mats);
+    renderer.present_frame().unwrap();
+    ctx.destroy();
+}


### PR DESCRIPTION
## Summary
- mutate skeletal mesh via `get_mut` instead of cloning
- add regression test calling `update_skeletal_bones` twice

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684504a3c9e0832abce23d5fc07fbb74