### PR TITLE
Add pipeline builder error tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ rusttype = "0.9"
 [dev-dependencies]
 serial_test = "2.0"
 
+[features]
+large-tests = []
+
 [build-dependencies]
 walkdir = "2.4.0"
 


### PR DESCRIPTION
## Summary
- expand tests for pipeline builder
- support optional `large-tests` feature
- limit large array test and mark ignored

## Testing
- `cargo test --quiet`
- `cargo test --quiet --features large-tests`


------
https://chatgpt.com/codex/tasks/task_e_6845e59e3554832a84f9ebcc5078f670