### PR TITLE
Add per-pass pipeline support in renderer

### DIFF
--- a/tests/bindless_lighting.rs
+++ b/tests/bindless_lighting.rs
@@ -39,7 +39,7 @@ fn bindless_lighting_sample() {
         .render_pass(renderer.render_pass(),0)
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
-    renderer.register_pso(RenderStage::Opaque, pso, bgr);
+    renderer.register_pipeline_for_pass("main", pso, bgr);
 
     let mut lights = BindlessLights::new();
     let light = LightDesc{ position:[0.0,0.0,0.0], intensity:1.0, color:[1.0,1.0,1.0], range:1.0, direction:[0.0,0.0,-1.0], _pad:0 };

--- a/tests/bindless_rendering.rs
+++ b/tests/bindless_rendering.rs
@@ -40,7 +40,7 @@ fn bindless_rendering_sample() {
         .render_pass(renderer.render_pass(),0)
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
-    renderer.register_pso(RenderStage::Opaque, pso, bgr);
+    renderer.register_pipeline_for_pass("main", pso, bgr);
 
     let mut bindless = BindlessData::new();
     let tex_data:[u8;4] = [255,0,0,255];

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -48,7 +48,7 @@ fn render_pbr_quad() {
 
     let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(),0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
-    renderer.register_pso(RenderStage::Opaque, pso, bgr);
+    renderer.register_pipeline_for_pass("main", pso, bgr);
 
     let mesh = StaticMesh {
         vertices: quad_vertices(),

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -100,7 +100,7 @@ fn render_triangle_and_cube() {
     let bind_group_resources = pso.create_bind_groups(&renderer.resources()).unwrap();
 
     // Register pipeline+resources
-    renderer.register_pso(RenderStage::Opaque, pso, bind_group_resources);
+    renderer.register_pipeline_for_pass("main", pso, bind_group_resources);
 
     // Register triangle
     let triangle_mesh = StaticMesh {

--- a/tests/static_movement.rs
+++ b/tests/static_movement.rs
@@ -41,7 +41,7 @@ fn static_mesh_with_movement() {
         .render_pass(renderer.render_pass(),0)
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
-    renderer.register_pso(RenderStage::Opaque,pso,bgr);
+    renderer.register_pipeline_for_pass("main", pso, bgr);
 
     let mesh = StaticMesh {
         vertices: vec![

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -29,7 +29,7 @@ fn draw_text_2d() {
         .render_pass(renderer.render_pass(), 0)
         .build();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
-    renderer.register_pso(RenderStage::Text, pso, bgr);
+    renderer.register_pipeline_for_pass("main", pso, bgr);
 
     let font_bytes: &[u8] = include_bytes!("../assets/data/DejaVuSans.ttf");
     let text = TextRenderer2D::new(font_bytes);


### PR DESCRIPTION
## Summary
- support render pass specific pipelines via `Renderer::register_pipeline_for_pass`
- track stage pipelines separately from pass pipelines
- update tests to register pipelines for the `main` pass

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846411bfdac832a875a2a3e209843be