### PR TITLE
Add material-based pipeline selection

### DIFF
--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -59,13 +59,14 @@ pub fn run(ctx: &mut Context) {
     let (verts, inds) = make_sphere(8, 16);
     for _ in 0..3 {
         let mesh = StaticMesh {
+            material_id: "pbr".into(),
             vertices: verts.clone(),
             indices: Some(inds.clone()),
             vertex_buffer: None,
             index_buffer: None,
             index_count: 0,
         };
-        renderer.register_static_mesh(mesh, None);
+        renderer.register_static_mesh(mesh, None, "pbr".into());
     }
 
     let white: [u8; 4] = [255, 255, 255, 255];

--- a/src/gltf/mod.rs
+++ b/src/gltf/mod.rs
@@ -118,6 +118,7 @@ fn load_node(
                     })
                     .collect();
                 let mut mesh = SkeletalMesh {
+                    material_id: "default".into(),
                     vertices: verts,
                     indices,
                     vertex_buffer: None,
@@ -144,6 +145,7 @@ fn load_node(
                     })
                     .collect();
                 MeshData::Static(StaticMesh {
+                    material_id: "default".into(),
                     vertices: verts,
                     indices,
                     vertex_buffer: None,

--- a/src/renderer/drawable.rs
+++ b/src/renderer/drawable.rs
@@ -36,6 +36,7 @@ pub struct SkeletalVertex {
 }
 
 pub struct StaticMesh {
+    pub material_id: String,
     pub vertices: Vec<Vertex>,
     pub indices: Option<Vec<u32>>,
     pub vertex_buffer: Option<Handle<Buffer>>,
@@ -119,6 +120,7 @@ impl SkeletalMesh {
 /// Skeletal mesh data with optional GPU resources.
 #[derive(Debug, Clone)]
 pub struct SkeletalMesh {
+    pub material_id: String,
     pub vertices: Vec<SkeletalVertex>,
     pub indices: Option<Vec<u32>>,
     pub vertex_buffer: Option<Handle<Buffer>>,
@@ -166,6 +168,7 @@ mod tests {
     fn upload_static_mesh_sets_buffers_valid() {
         let mut ctx = make_ctx();
         let mut mesh = StaticMesh {
+            material_id: "test".into(),
             vertices: vec![simple_vertex(), simple_vertex(), simple_vertex()],
             indices: Some(vec![0, 1, 2]),
             vertex_buffer: None,
@@ -186,6 +189,7 @@ mod tests {
         let mut ctx = make_ctx();
         let skeleton = Skeleton { bones: vec![Bone::default(); 2] };
         let mut mesh = SkeletalMesh {
+            material_id: "test".into(),
             vertices: vec![simple_skel_vertex()],
             indices: None,
             vertex_buffer: None,
@@ -210,6 +214,7 @@ mod tests {
         let mut ctx = make_ctx();
         let skeleton = Skeleton { bones: vec![Bone::default(); 2] };
         let mut mesh = SkeletalMesh {
+            material_id: "test".into(),
             vertices: vec![simple_skel_vertex()],
             indices: None,
             vertex_buffer: None,
@@ -237,6 +242,7 @@ mod tests {
         let mut ctx = make_ctx();
         let skeleton = Skeleton { bones: vec![Bone::default()] };
         let mesh = SkeletalMesh {
+            material_id: "test".into(),
             vertices: vec![simple_skel_vertex()],
             indices: None,
             vertex_buffer: None,

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -82,6 +82,13 @@ impl<'a> TextRenderer2D<'a> {
             Vertex { position: [pos[0], pos[1], 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[0.0,0.0], color:[1.0;4]},
         ];
         let indices = vec![0u32,1,2,2,3,0];
-        StaticMesh { vertices: verts, indices: Some(indices), vertex_buffer: None, index_buffer: None, index_count: 0 }
+        StaticMesh {
+            material_id: "text".into(),
+            vertices: verts,
+            indices: Some(indices),
+            vertex_buffer: None,
+            index_buffer: None,
+            index_count: 0,
+        }
     }
 }

--- a/tests/bindless_lighting.rs
+++ b/tests/bindless_lighting.rs
@@ -47,6 +47,7 @@ fn bindless_lighting_sample() {
     lights.register(renderer.resources());
 
     let mesh = StaticMesh {
+        material_id: "lighting".into(),
         vertices: vec![
             Vertex{position:[-0.5,-0.5,0.0],normal:[0.0,0.0,1.0],tangent:[1.0,0.0,0.0,1.0],uv:[0.0,0.0],color:[1.0,1.0,1.0,1.0]},
             Vertex{position:[0.5,-0.5,0.0],normal:[0.0,0.0,1.0],tangent:[1.0,0.0,0.0,1.0],uv:[1.0,0.0],color:[1.0,1.0,1.0,1.0]},
@@ -57,7 +58,7 @@ fn bindless_lighting_sample() {
         index_buffer: None,
         index_count: 0,
     };
-    renderer.register_static_mesh(mesh,None);
+    renderer.register_static_mesh(mesh,None,"lighting".into());
 
     renderer.present_frame().unwrap();
     ctx.destroy();

--- a/tests/bindless_rendering.rs
+++ b/tests/bindless_rendering.rs
@@ -55,6 +55,7 @@ fn bindless_rendering_sample() {
     bindless.register(renderer.resources());
 
     let mesh = StaticMesh {
+        material_id: "bindless".into(),
         vertices: vec![
             Vertex{position:[0.0,-0.5,0.0],normal:[0.0,0.0,1.0],tangent:[1.0,0.0,0.0,1.0],uv:[0.0,0.0],color:[1.0,1.0,1.0,1.0]},
             Vertex{position:[0.5,0.5,0.0],normal:[0.0,0.0,1.0],tangent:[1.0,0.0,0.0,1.0],uv:[1.0,1.0],color:[1.0,1.0,1.0,1.0]},
@@ -65,7 +66,7 @@ fn bindless_rendering_sample() {
         index_buffer: None,
         index_count: 0,
     };
-    renderer.register_static_mesh(mesh,None);
+    renderer.register_static_mesh(mesh,None,"bindless".into());
     renderer.present_frame().unwrap();
     ctx.destroy();
 }

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -51,13 +51,14 @@ fn render_pbr_quad() {
     renderer.register_pipeline_for_pass("main", pso, bgr);
 
     let mesh = StaticMesh {
+        material_id: "pbr".into(),
         vertices: quad_vertices(),
         indices: Some(quad_indices()),
         vertex_buffer: None,
         index_buffer: None,
         index_count: 0,
     };
-    renderer.register_static_mesh(mesh,None);
+    renderer.register_static_mesh(mesh,None,"pbr".into());
 
     // register textures
     let white: [u8;4] = [255,255,255,255];

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -104,23 +104,25 @@ fn render_triangle_and_cube() {
 
     // Register triangle
     let triangle_mesh = StaticMesh {
+        material_id: "color".into(),
         vertices: triangle_vertices(),
         indices: None,
         vertex_buffer: None,
         index_buffer: None,
         index_count: 0,
     };
-    renderer.register_static_mesh(triangle_mesh, None);
+    renderer.register_static_mesh(triangle_mesh, None, "color".into());
 
     // Register cube
     let cube_mesh = StaticMesh {
+        material_id: "color".into(),
         vertices: cube_vertices(),
         indices: Some(cube_indices()),
         vertex_buffer: None,
         index_buffer: None,
         index_count: 0,
     };
-    renderer.register_static_mesh(cube_mesh, None);
+    renderer.register_static_mesh(cube_mesh, None, "color".into());
 
     // Main loop: just draw both objects with same pipeline/PSO/bind group
     renderer.render_loop(|_r| {

--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -22,7 +22,7 @@ fn render_simple_skeleton() {
         _ => panic!("expected skeletal mesh"),
     };
     let bone_count = mesh.skeleton.bone_count();
-    renderer.register_skeletal_mesh(mesh);
+    renderer.register_skeletal_mesh(mesh, "skin".into());
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
@@ -51,7 +51,7 @@ fn update_bones_twice() {
         _ => panic!("expected skeletal mesh"),
     };
     let bone_count = mesh.skeleton.bone_count();
-    renderer.register_skeletal_mesh(mesh);
+    renderer.register_skeletal_mesh(mesh, "skin".into());
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();

--- a/tests/skinned_mesh_render.rs
+++ b/tests/skinned_mesh_render.rs
@@ -18,7 +18,7 @@ fn skinned_mesh_render() {
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh { MeshData::Skeletal(m) => m.clone(), _ => panic!("expected skel") };
     let bone_count = mesh.skeleton.bone_count();
-    renderer.register_skeletal_mesh(mesh);
+    renderer.register_skeletal_mesh(mesh, "skin".into());
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(),0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();

--- a/tests/static_movement.rs
+++ b/tests/static_movement.rs
@@ -44,6 +44,7 @@ fn static_mesh_with_movement() {
     renderer.register_pipeline_for_pass("main", pso, bgr);
 
     let mesh = StaticMesh {
+        material_id: "default".into(),
         vertices: vec![
             Vertex{position:[-0.5,-0.5,0.0],normal:[0.0,0.0,1.0],tangent:[1.0,0.0,0.0,1.0],uv:[0.0,0.0],color:[1.0,1.0,1.0,1.0]},
             Vertex{position:[0.5,-0.5,0.0],normal:[0.0,0.0,1.0],tangent:[1.0,0.0,0.0,1.0],uv:[1.0,0.0],color:[1.0,1.0,1.0,1.0]},
@@ -54,7 +55,7 @@ fn static_mesh_with_movement() {
         index_buffer: None,
         index_count: 0,
     };
-    renderer.register_static_mesh(mesh,None);
+    renderer.register_static_mesh(mesh,None,"default".into());
 
     // move vertices slightly
     let new_verts = vec![


### PR DESCRIPTION
## Summary
- add `material_id` to mesh structs
- allow registering pipelines per material
- use `material_id` when rendering
- update mesh constructors and examples/tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846560acc70832aa38b82c719aad82c