### PR TITLE
Add glTF animation loading

### DIFF
--- a/tests/gltf_loader.rs
+++ b/tests/gltf_loader.rs
@@ -21,6 +21,10 @@ fn load_simple_skin() {
         }
         _ => panic!("expected skeletal mesh"),
     }
+    assert_eq!(scene.animations.len(), 1);
+    let clip = &scene.animations[0];
+    assert_eq!(clip.tracks.len(), 3);
+    assert!(!clip.tracks[2].is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend `Scene` to include animation clips
- parse animations in `load_scene`
- build clips from glTF channels
- test loading of sample animation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b3bb4dc60832abc607e0cff16a4fa