### PR TITLE
Add skeletal instance support

### DIFF
--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -2,6 +2,7 @@ use koji::renderer::*;
 use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
 use glam::Mat4;
+use koji::animation::Animator;
 use dashi::*;
 use serial_test::serial;
 
@@ -22,14 +23,15 @@ fn render_simple_skeleton() {
         _ => panic!("expected skeletal mesh"),
     };
     let bone_count = mesh.skeleton.bone_count();
-    renderer.register_skeletal_mesh(mesh, "skin".into());
+    let instance = SkeletalInstance::new(&mut ctx, Animator::new(mesh.skeleton.clone())).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso, bgr);
 
     let mats = vec![Mat4::IDENTITY; bone_count];
-    renderer.update_skeletal_bones(0, &mats);
+    renderer.update_skeletal_bones(0, 0, &mats);
     renderer.present_frame().unwrap();
     ctx.destroy();
 }
@@ -51,15 +53,16 @@ fn update_bones_twice() {
         _ => panic!("expected skeletal mesh"),
     };
     let bone_count = mesh.skeleton.bone_count();
-    renderer.register_skeletal_mesh(mesh, "skin".into());
+    let instance = SkeletalInstance::new(&mut ctx, Animator::new(mesh.skeleton.clone())).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso, bgr);
 
     let mats = vec![Mat4::IDENTITY; bone_count];
-    renderer.update_skeletal_bones(0, &mats);
-    renderer.update_skeletal_bones(0, &mats);
+    renderer.update_skeletal_bones(0, 0, &mats);
+    renderer.update_skeletal_bones(0, 0, &mats);
     renderer.present_frame().unwrap();
     ctx.destroy();
 }

--- a/tests/skinned_mesh_render.rs
+++ b/tests/skinned_mesh_render.rs
@@ -2,6 +2,7 @@ use koji::renderer::*;
 use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
 use glam::Mat4;
+use koji::animation::Animator;
 use dashi::*;
 use serial_test::serial;
 
@@ -18,14 +19,15 @@ fn skinned_mesh_render() {
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh { MeshData::Skeletal(m) => m.clone(), _ => panic!("expected skel") };
     let bone_count = mesh.skeleton.bone_count();
-    renderer.register_skeletal_mesh(mesh, "skin".into());
+    let instance = SkeletalInstance::new(&mut ctx, Animator::new(mesh.skeleton.clone())).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
     let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(),0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso,bgr);
 
     let mats = vec![Mat4::IDENTITY; bone_count];
-    renderer.update_skeletal_bones(0,&mats);
+    renderer.update_skeletal_bones(0,0,&mats);
     renderer.present_frame().unwrap();
     ctx.destroy();
 }


### PR DESCRIPTION
## Summary
- introduce `SkeletalInstance` for per-instance bone buffers and animation
- register skeletal meshes with associated instances in the renderer
- update rendering to handle multiple skeletal instances
- adjust tests for new interface

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684b43962e50832a92c5e1065be36773