### PR TITLE
Make integration tests optional examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,31 @@ path = "examples/pbr_spheres/bin.rs"
 name = "custom_pass"
 path = "examples/custom_pass/bin.rs"
 
+[[example]]
+name = "bindless_lighting"
+path = "examples/bindless_lighting/bin.rs"
+
+[[example]]
+name = "bindless_rendering"
+path = "examples/bindless_rendering/bin.rs"
+
+[[example]]
+name = "pbr_renderer"
+path = "examples/pbr_renderer/bin.rs"
+
+[[example]]
+name = "skinned_mesh_render"
+path = "examples/skinned_mesh_render/bin.rs"
+
+[[example]]
+name = "skeletal_renderer"
+path = "examples/skeletal_renderer/bin.rs"
+
+[[example]]
+name = "static_movement"
+path = "examples/static_movement/bin.rs"
+
+[[example]]
+name = "text2d"
+path = "examples/text2d/bin.rs"
+

--- a/README.md
+++ b/README.md
@@ -31,12 +31,7 @@ cargo test
 
 ## Sample Binaries
 
-Three examples live under the `examples/` directory and can be run with:
-
-```bash
-cargo run --example sample           # basic triangle sample
-cargo run --example deferred_sample  # deferred rendering example
-cargo run --example shadow_sample    # cascaded shadow map demo
-```
-
-These demos compile included GLSL files in `assets/shaders/` and open an SDL2 window.
+Example programs live under the `examples/` directory and can be run with
+`cargo run --example <name>`. Some of the heavier demos are gated behind the
+`gpu_tests` feature flag. See [examples/README.md](examples/README.md) for a
+description of each example and exact commands.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,28 @@
+# Running the Examples
+
+Each subdirectory provides a small demo showcasing some feature of **Koji**. The
+examples can be run with `cargo run --example <name>`.
+
+Most demos compile shaders from the `assets/shaders/` directory and open an SDL2
+window. Heavier integrations that were originally tests (such as bindless or
+skeletal rendering) are behind the `gpu_tests` feature flag.
+
+```
+cargo run --example sample                        # run the triangle sample
+cargo run --features gpu_tests --example text2d   # run an example requiring gpu_tests
+```
+
+## Available Examples
+
+- **sample** – draw a single triangle
+- **deferred_sample** – basic deferred rendering
+- **shadow_sample** – cascaded shadow maps
+- **pbr_spheres** – grid of spheres with PBR shading
+- **custom_pass** – building a render pass from a YAML description
+- **bindless_rendering** – textured triangle using bindless resources *(gpu_tests)*
+- **bindless_lighting** – simple lighting with bindless buffers *(gpu_tests)*
+- **pbr_renderer** – textured quad with the PBR material *(gpu_tests)*
+- **skinned_mesh_render** – render a skinned glTF mesh *(gpu_tests)*
+- **skeletal_renderer** – skeleton rendering and bone updates *(gpu_tests)*
+- **static_movement** – update vertices of a static mesh *(gpu_tests)*
+- **text2d** – draw 2D text using the text renderer *(gpu_tests)*

--- a/examples/bindless_lighting/bin.rs
+++ b/examples/bindless_lighting/bin.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "gpu_tests")]
+mod bindless_lighting {
+    include!("../../tests/bindless_lighting.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    bindless_lighting::run();
+}

--- a/examples/bindless_rendering/bin.rs
+++ b/examples/bindless_rendering/bin.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "gpu_tests")]
+mod bindless_rendering {
+    include!("../../tests/bindless_rendering.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    bindless_rendering::run();
+}

--- a/examples/pbr_renderer/bin.rs
+++ b/examples/pbr_renderer/bin.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "gpu_tests")]
+mod pbr_renderer {
+    include!("../../tests/pbr_renderer.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    pbr_renderer::run();
+}

--- a/examples/skeletal_renderer/bin.rs
+++ b/examples/skeletal_renderer/bin.rs
@@ -1,0 +1,12 @@
+#[cfg(feature = "gpu_tests")]
+mod skeletal_renderer {
+    include!("../../tests/skeletal_renderer.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    {
+        skeletal_renderer::run_simple_skeleton();
+        skeletal_renderer::run_update_bones_twice();
+    }
+}

--- a/examples/skinned_mesh_render/bin.rs
+++ b/examples/skinned_mesh_render/bin.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "gpu_tests")]
+mod skinned_mesh_render {
+    include!("../../tests/skinned_mesh_render.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    skinned_mesh_render::run();
+}

--- a/examples/static_movement/bin.rs
+++ b/examples/static_movement/bin.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "gpu_tests")]
+mod static_movement {
+    include!("../../tests/static_movement.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    static_movement::run();
+}

--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "gpu_tests")]
+mod text2d {
+    include!("../../tests/text2d.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    text2d::run();
+}

--- a/tests/bindless_lighting.rs
+++ b/tests/bindless_lighting.rs
@@ -1,7 +1,6 @@
 use koji::material::*;
 use koji::renderer::*;
 use dashi::*;
-use serial_test::serial;
 use inline_spirv::inline_spirv;
 
 fn vert() -> Vec<u32> {
@@ -23,10 +22,8 @@ fn frag() -> Vec<u32> {
     ).to_vec()
 }
 
-#[test]
-#[serial]
-#[ignore]
-fn bindless_lighting_sample() {
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
     let device = DeviceSelector::new().unwrap()
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
@@ -62,4 +59,17 @@ fn bindless_lighting_sample() {
 
     renderer.present_frame().unwrap();
     ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn bindless_lighting_sample() {
+        run();
+    }
 }

--- a/tests/bindless_rendering.rs
+++ b/tests/bindless_rendering.rs
@@ -1,7 +1,7 @@
 use koji::material::*;
 use koji::renderer::*;
 use dashi::*;
-use serial_test::serial;
+
 use inline_spirv::inline_spirv;
 
 fn simple_vert() -> Vec<u32> {
@@ -22,10 +22,8 @@ fn simple_frag() -> Vec<u32> {
     ).to_vec()
 }
 
-#[test]
-#[serial]
-#[ignore]
-fn bindless_rendering_sample() {
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
     let device = DeviceSelector::new().unwrap()
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
@@ -69,4 +67,17 @@ fn bindless_rendering_sample() {
     renderer.register_static_mesh(mesh,None,"bindless".into());
     renderer.present_frame().unwrap();
     ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn bindless_rendering_sample() {
+        run();
+    }
 }

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -1,7 +1,7 @@
 use koji::material::*;
 use koji::renderer::*;
 use dashi::*;
-use serial_test::serial;
+
 use inline_spirv::include_spirv;
 use koji::material::pipeline_builder::PipelineBuilder;
 use dashi::utils::Handle;
@@ -38,10 +38,8 @@ fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -
         .build()
 }
 
-#[test]
-#[serial]
-#[ignore]
-fn render_pbr_quad() {
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
     let device = DeviceSelector::new().unwrap().select(DeviceFilter::default().add_required_type(DeviceType::Dedicated)).unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo{ device }).unwrap();
     let mut renderer = Renderer::new(320,240,"pbr", &mut ctx).expect("renderer");
@@ -72,4 +70,17 @@ fn render_pbr_quad() {
 
     renderer.present_frame().unwrap();
     ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn render_pbr_quad() {
+        run();
+    }
 }

--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -3,12 +3,9 @@ use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
 use glam::Mat4;
 use dashi::*;
-use serial_test::serial;
 
-#[test]
-#[serial]
-#[ignore]
-fn render_simple_skeleton() {
+#[cfg(feature = "gpu_tests")]
+pub fn run_simple_skeleton() {
     let device = DeviceSelector::new()
         .unwrap()
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
@@ -34,10 +31,8 @@ fn render_simple_skeleton() {
     ctx.destroy();
 }
 
-#[test]
-#[serial]
-#[ignore]
-fn update_bones_twice() {
+#[cfg(feature = "gpu_tests")]
+pub fn run_update_bones_twice() {
     let device = DeviceSelector::new()
         .unwrap()
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
@@ -62,4 +57,24 @@ fn update_bones_twice() {
     renderer.update_skeletal_bones(0, &mats);
     renderer.present_frame().unwrap();
     ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn render_simple_skeleton() {
+        run_simple_skeleton();
+    }
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn update_bones_twice() {
+        run_update_bones_twice();
+    }
 }

--- a/tests/skinned_mesh_render.rs
+++ b/tests/skinned_mesh_render.rs
@@ -3,12 +3,9 @@ use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
 use glam::Mat4;
 use dashi::*;
-use serial_test::serial;
 
-#[test]
-#[serial]
-#[ignore]
-fn skinned_mesh_render() {
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
     let device = DeviceSelector::new().unwrap()
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
@@ -28,4 +25,17 @@ fn skinned_mesh_render() {
     renderer.update_skeletal_bones(0,&mats);
     renderer.present_frame().unwrap();
     ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn skinned_mesh_render() {
+        run();
+    }
 }

--- a/tests/static_movement.rs
+++ b/tests/static_movement.rs
@@ -1,7 +1,7 @@
 use koji::material::*;
 use koji::renderer::*;
 use dashi::*;
-use serial_test::serial;
+
 use inline_spirv::inline_spirv;
 
 fn vert() -> Vec<u32> {
@@ -25,10 +25,8 @@ fn make_vertex(pos:[f32;3]) -> Vertex {
     Vertex { position:pos, normal:[0.0,0.0,1.0], tangent:[1.0,0.0,0.0,1.0], uv:[0.0,0.0], color:[1.0,1.0,1.0,1.0] }
 }
 
-#[test]
-#[serial]
-#[ignore]
-fn static_mesh_with_movement() {
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
     let device = DeviceSelector::new().unwrap()
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
@@ -67,4 +65,17 @@ fn static_mesh_with_movement() {
 
     renderer.present_frame().unwrap();
     ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn static_mesh_with_movement() {
+        run();
+    }
 }

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -3,7 +3,6 @@ use koji::renderer::*;
 use koji::text::*;
 use dashi::*;
 use inline_spirv::include_spirv;
-use serial_test::serial;
 
 fn make_vert() -> Vec<u32> {
     include_spirv!("assets/shaders/text.vert", vert).to_vec()
@@ -13,10 +12,8 @@ fn make_frag() -> Vec<u32> {
     include_spirv!("assets/shaders/text.frag", frag).to_vec()
 }
 
-#[test]
-#[serial]
-#[ignore]
-fn draw_text_2d() {
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
     let device = DeviceSelector::new().unwrap().select(DeviceFilter::default().add_required_type(DeviceType::Dedicated)).unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo { device }).unwrap();
     let mut renderer = Renderer::new(320, 240, "text", &mut ctx).expect("renderer");
@@ -39,4 +36,17 @@ fn draw_text_2d() {
 
     renderer.present_frame().unwrap();
     ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn draw_text_2d() {
+        run();
+    }
 }


### PR DESCRIPTION
## Summary
- gate heavy integration tests behind the `gpu_tests` feature
- expose those tests as runnable examples
- document examples in a new `examples/README.md`
- link to the examples list from the project README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684b430e1ee8832aac2d3a5222071ee3