### PR TITLE
Add skeletal animation helper and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ name = "skeletal_renderer"
 path = "examples/skeletal_renderer/bin.rs"
 
 [[example]]
+name = "skeletal_animation"
+path = "examples/skeletal_animation/bin.rs"
+
+[[example]]
 name = "static_movement"
 path = "examples/static_movement/bin.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,5 +24,6 @@ cargo run --features gpu_tests --example text2d   # run an example requiring gpu
 - **pbr_renderer** – textured quad with the PBR material *(gpu_tests)*
 - **skinned_mesh_render** – render a skinned glTF mesh *(gpu_tests)*
 - **skeletal_renderer** – skeleton rendering and bone updates *(gpu_tests)*
+- **skeletal_animation** – play an animated skeletal mesh *(gpu_tests)*
 - **static_movement** – update vertices of a static mesh *(gpu_tests)*
 - **text2d** – draw 2D text using the text renderer *(gpu_tests)*

--- a/examples/skeletal_animation/bin.rs
+++ b/examples/skeletal_animation/bin.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "gpu_tests")]
+mod skeletal_animation {
+    include!("../../tests/skeletal_animation.rs");
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    skeletal_animation::run();
+}

--- a/src/renderer/drawable.rs
+++ b/src/renderer/drawable.rs
@@ -134,6 +134,7 @@ pub struct SkeletalMesh {
 pub struct SkeletalInstance {
     pub animator: Animator,
     pub bone_buffer: Handle<Buffer>,
+    pub player: Option<crate::animation::clip::AnimationPlayer>,
 }
 
 impl SkeletalInstance {
@@ -146,7 +147,18 @@ impl SkeletalInstance {
             usage: BufferUsage::STORAGE,
             initial_data: None,
         })?;
-        Ok(Self { animator, bone_buffer })
+        Ok(Self { animator, bone_buffer, player: None })
+    }
+
+    /// Create a new instance with an animation player.
+    pub fn with_player(
+        ctx: &mut Context,
+        animator: Animator,
+        player: crate::animation::clip::AnimationPlayer,
+    ) -> Result<Self, GPUError> {
+        let mut inst = Self::new(ctx, animator)?;
+        inst.player = Some(player);
+        Ok(inst)
     }
 
     /// Upload the animator's matrices to the GPU buffer.

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -260,6 +260,20 @@ impl Renderer {
         }
     }
 
+    /// Advance an animation player and upload the new bone matrices.
+    pub fn play_animation(&mut self, mesh_idx: usize, inst_idx: usize, dt: f32) {
+        let ctx = self.get_ctx();
+        if let Some((_mesh, instances)) = self.skeletal_meshes.get_mut(mesh_idx) {
+            if let Some(inst) = instances.get_mut(inst_idx) {
+                if let Some(player) = inst.player.as_mut() {
+                    let local = player.advance(dt);
+                    inst.animator.update(&local);
+                    let _ = inst.update_gpu(ctx);
+                }
+            }
+        }
+    }
+
     /// Present one frame to display (for tests or non-interactive draw)
     pub fn present_frame(&mut self) -> Result<(), GPUError> {
         let ctx = self.get_ctx();

--- a/tests/skeletal_animation.rs
+++ b/tests/skeletal_animation.rs
@@ -1,0 +1,44 @@
+use koji::renderer::*;
+use koji::gltf::{load_scene, MeshData};
+use koji::material::*;
+use koji::animation::{Animator};
+use koji::animation::clip::AnimationPlayer;
+use dashi::*;
+
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
+    let device = DeviceSelector::new().unwrap()
+        .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+        .unwrap_or_default();
+    let mut ctx = Context::new(&ContextInfo{ device }).unwrap();
+    let mut renderer = Renderer::new(320,240,"anim", &mut ctx).unwrap();
+
+    let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
+    let mesh = match &scene.meshes[0].mesh { MeshData::Skeletal(m) => m.clone(), _ => panic!("expected skel") };
+    let clip = scene.animations[0].clone();
+    let player = AnimationPlayer::new(clip);
+    let animator = Animator::new(mesh.skeleton.clone());
+    let instance = SkeletalInstance::with_player(&mut ctx, animator, player).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
+
+    let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(),0);
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_skeletal_pso(pso,bgr);
+
+    renderer.play_animation(0,0,0.5);
+    renderer.present_frame().unwrap();
+    ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn skeletal_animation() {
+        run();
+    }
+}


### PR DESCRIPTION
## Summary
- add `AnimationPlayer` optional field to `SkeletalInstance`
- implement `Renderer::play_animation` to advance animations
- create `SkeletalInstance::with_player`
- add skeletal animation example and tests
- document new example in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684b4a750f14832ab3a9f03081a75f40