### PR TITLE
Update docs to mention winit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Koji is a small rendering crate built on top of [Dashi](https://github.com/JordanHendl/dashi).  
 It provides helpers for building render pipelines, loading `glTF` assets and drawing text.
-SPIR-V shaders are compiled at build time via `inline-spirv` and SDL2 is used for windowing.
+SPIR-V shaders are compiled at build time via `inline-spirv`, and window creation/event handling is done through **winit**.
 
 ## Dependencies
 
@@ -10,7 +10,7 @@ Key dependencies include:
 
 - **dashi** &ndash; GPU and Vulkan abstractions used by Koji
 - **glam** &ndash; math types (vectors, matrices)
-- **sdl2** &ndash; window/event handling
+- **winit** &ndash; window/event handling
 - **rhai** &ndash; optional scripting support
 - **serde**, **serde_yaml**, **indexmap** &ndash; data serialization
 - **gltf**, **rusttype** &ndash; asset loading and fonts

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Each subdirectory provides a small demo showcasing some feature of **Koji**. The
 examples can be run with `cargo run --example <name>`.
 
-Most demos compile shaders from the `assets/shaders/` directory and open an SDL2
+Most demos compile shaders from the `assets/shaders/` directory and open a winit
 window. Heavier integrations that were originally tests (such as bindless or
 skeletal rendering) are behind the `gpu_tests` feature flag.
 

--- a/examples/sample_shadows/bin.rs
+++ b/examples/sample_shadows/bin.rs
@@ -390,7 +390,7 @@ pub fn run(ctx: &mut Context) {
         })
         .unwrap();
 
-    // -- SDL and Render Loop --
+    // -- Winit and Render Loop --
     let mut display = ctx.make_display(&Default::default()).unwrap();
     let mut framed = FramedCommandList::new(ctx, "csm_frame", 2);
     let semaphores = ctx.make_semaphores(2).unwrap();
@@ -481,8 +481,8 @@ pub fn main() {
 //use dashi::*;
 //use inline_spirv::inline_spirv;
 //use koji::*;
-//use sdl2::event::Event;
-//use sdl2::keyboard::Keycode;
+//use winit::event::Event;
+//use winit::event::VirtualKeyCode;
 //use std::time::Instant;
 //
 //pub fn run(ctx: &mut Context) {
@@ -603,16 +603,16 @@ pub fn main() {
 //    let mut display = ctx.make_display(&Default::default()).unwrap();
 //    let semaphores = ctx.make_semaphores(2).unwrap();
 //    let mut framed = FramedCommandList::new(ctx, "cascaded", 2);
-//    let mut event_pump = ctx.get_sdl_ctx().event_pump().unwrap();
+//    let event_loop = display.winit_event_loop();
 //    let mut _timer = Instant::now();
 //
 //    'main: loop {
-//        for e in event_pump.poll_iter() {
+//        for e in event_loop.poll_iter() {
 //            if matches!(
 //                e,
-//                Event::Quit { .. }
+//                Event::WindowEvent { .. }
 //                    | Event::KeyDown {
-//                        keycode: Some(Keycode::Escape),
+//                        keycode: Some(VirtualKeyCode::Escape),
 //                        ..
 //                    }
 //            ) {


### PR DESCRIPTION
## Summary
- update README to describe windowing/event handling via winit
- switch dependency bullet to `winit`
- tweak examples/README note about opening a winit window
- replace remaining SDL2 mentions in sample_shadows example

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_684c773a87c4832a86d56f885cf41397