### PR TITLE
Ensure cleanup in examples

### DIFF
--- a/examples/sample_deferred/bin.rs
+++ b/examples/sample_deferred/bin.rs
@@ -221,4 +221,5 @@ pub fn main() {
     let mut ctx = Context::new(&ContextInfo { device }).unwrap();
 
     run(&mut ctx);
+    ctx.destroy();
 }

--- a/examples/sample_shadows/bin.rs
+++ b/examples/sample_shadows/bin.rs
@@ -474,4 +474,5 @@ pub fn main() {
 
     let mut ctx = Context::new(&ContextInfo { device }).unwrap();
     run(&mut ctx);
+    ctx.destroy();
 }


### PR DESCRIPTION
## Summary
- call `ctx.destroy()` in deferred and shadow examples
- verify all example binaries clean up context

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684ca32d34ec832a8a9c9ee246f58f90