### PR TITLE
Fix deferred sample uniform name

### DIFF
--- a/assets/shaders/lighting.frag
+++ b/assets/shaders/lighting.frag
@@ -10,7 +10,7 @@ struct Light {
 layout(set = 0, binding = 0) uniform sampler2D albedoTex;
 layout(set = 0, binding = 1) uniform sampler2D normalTex;
 layout(set = 0, binding = 2) buffer Lights { Light lights[]; };
-layout(set = 0, binding = 3) uniform LightCount { uint count; };
+layout(set = 0, binding = 3) uniform LightCount { uint count; } light_count;
 
 layout(location = 0) out vec4 outColor;
 
@@ -21,7 +21,7 @@ void main() {
 
     vec3 view_dir = vec3(0.0, 0.0, 1.0);
     vec3 result = vec3(0.0);
-    for (uint i = 0u; i < count; ++i) {
+    for (uint i = 0u; i < light_count.count; ++i) {
         vec3 light_dir = normalize(lights[i].position);
         float diff = max(dot(normal, light_dir), 0.0);
         vec3 half_dir = normalize(light_dir + view_dir);

--- a/examples/sample_deferred/bin.rs
+++ b/examples/sample_deferred/bin.rs
@@ -131,7 +131,7 @@ pub fn run(ctx: &mut Context) {
     );
     let light_count = lights.lights.lock().unwrap().len();
     lights.register(&mut resources);
-    resources.register_variable("", ctx, light_count);
+    resources.register_variable("light_count", ctx, light_count);
 
     let lighting_bg = pso_lighting.create_bind_group(0, &resources).unwrap();
 


### PR DESCRIPTION
## Summary
- register `light_count` variable for deferred lighting example
- match uniform variable name in shader

## Testing
- `cargo build --example deferred_sample`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684ca34018f4832aa1149e5d9ec8c403