### PR TITLE
Fix texture registration order in PBR test

### DIFF
--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -45,6 +45,17 @@ pub fn run() {
     let mut renderer = Renderer::new(320,240,"pbr", &mut ctx).expect("renderer");
 
     let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(),0);
+
+    // register textures before creating bind groups
+    let white: [u8;4] = [255,255,255,255];
+    let img = ctx.make_image(&ImageInfo { debug_name:"alb", dim:[1,1,1], format:Format::RGBA8, mip_levels:1, layers:1, initial_data:Some(&white)}).unwrap();
+    let view = ctx.make_image_view(&ImageViewInfo{ img, ..Default::default() }).unwrap();
+    let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
+    renderer.resources().register_combined("albedo_map", img, view,[1,1], sampler);
+    renderer.resources().register_combined("normal_map", img, view,[1,1], sampler);
+    renderer.resources().register_combined("metallic_map", img, view,[1,1], sampler);
+    renderer.resources().register_combined("roughness_map", img, view,[1,1], sampler);
+
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);
 
@@ -58,15 +69,6 @@ pub fn run() {
     };
     renderer.register_static_mesh(mesh,None,"pbr".into());
 
-    // register textures
-    let white: [u8;4] = [255,255,255,255];
-    let img = ctx.make_image(&ImageInfo { debug_name:"alb", dim:[1,1,1], format:Format::RGBA8, mip_levels:1, layers:1, initial_data:Some(&white)}).unwrap();
-    let view = ctx.make_image_view(&ImageViewInfo{ img, ..Default::default() }).unwrap();
-    let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
-    renderer.resources().register_combined("albedo_map", img, view,[1,1], sampler);
-    renderer.resources().register_combined("normal_map", img, view,[1,1], sampler);
-    renderer.resources().register_combined("metallic_map", img, view,[1,1], sampler);
-    renderer.resources().register_combined("roughness_map", img, view,[1,1], sampler);
 
     renderer.present_frame().unwrap();
     ctx.destroy();


### PR DESCRIPTION
## Summary
- register PBR textures before creating bind groups
- keep PSO registration after bind group creation

## Testing
- `cargo test`
- `cargo test --features gpu_tests` *(fails: VmaAllocation_T::BlockAllocMap assertion)*

------
https://chatgpt.com/codex/tasks/task_e_684cb9b858a4832a8901ee75c61f58bb