### PR TITLE
Ensure samples loop

### DIFF
--- a/examples/custom_pass/bin.rs
+++ b/examples/custom_pass/bin.rs
@@ -65,8 +65,10 @@ subpasses:
     };
     renderer.register_static_mesh(mesh, None, "color".into());
 
-    // Draw a single frame
-    renderer.present_frame().unwrap();
+    // Render loop - nothing changes per frame in this simple sample
+    renderer.render_loop(|_r| {
+        // No dynamic updates
+    });
 }
 
 pub fn main() {

--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -100,7 +100,9 @@ pub fn run(ctx: &mut Context) {
         renderer.register_static_mesh(mesh, None, "pbr".into());
     }
 
-    renderer.present_frame().unwrap();
+    renderer.render_loop(|_r| {
+        // No per-frame updates required for this sample
+    });
 }
 
 pub fn main() {


### PR DESCRIPTION
## Summary
- make `pbr_spheres` run continuously using `render_loop`
- make `custom_pass` sample also loop

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684cc446d118832ab13ce93ad714e899