### PR TITLE
Use texture manager for PBR spheres

### DIFF
--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -3,6 +3,9 @@ use dashi::*;
 use inline_spirv::include_spirv;
 use koji::material::*;
 use koji::renderer::*;
+use koji::texture_manager;
+use koji::utils::ResourceManager;
+use std::path::Path;
 
 fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> PSO {
     let vert: &[u32] = include_spirv!("assets/shaders/pbr.vert", vert, glsl);
@@ -50,38 +53,69 @@ fn make_sphere(lat: u32, long: u32) -> (Vec<Vertex>, Vec<u32>) {
     (verts, idx)
 }
 
+fn register_textures(ctx: &mut Context, res: &mut ResourceManager) {
+    #[cfg(feature = "gpu_tests")]
+    {
+        let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
+        let albedo = texture_manager::load_from_file(
+            ctx,
+            res,
+            "albedo_map",
+            Path::new("assets/textures/albedo.png"),
+        );
+        let normal = texture_manager::load_from_file(
+            ctx,
+            res,
+            "normal_map",
+            Path::new("assets/textures/normal.png"),
+        );
+        let metallic = texture_manager::load_from_file(
+            ctx,
+            res,
+            "metallic_map",
+            Path::new("assets/textures/metallic.png"),
+        );
+        let roughness = texture_manager::load_from_file(
+            ctx,
+            res,
+            "roughness_map",
+            Path::new("assets/textures/roughness.png"),
+        );
+
+        // Override texture bindings with combined samplers
+        let a = *res.textures.get_ref(albedo);
+        res.remove("albedo_map");
+        res.register_combined("albedo_map", a.handle, a.view, a.dim, sampler);
+
+        let n = *res.textures.get_ref(normal);
+        res.remove("normal_map");
+        res.register_combined("normal_map", n.handle, n.view, n.dim, sampler);
+
+        let m = *res.textures.get_ref(metallic);
+        res.remove("metallic_map");
+        res.register_combined("metallic_map", m.handle, m.view, m.dim, sampler);
+
+        let r = *res.textures.get_ref(roughness);
+        res.remove("roughness_map");
+        res.register_combined("roughness_map", r.handle, r.view, r.dim, sampler);
+    }
+
+    #[cfg(not(feature = "gpu_tests"))]
+    {
+        let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
+        let white: [u8; 4] = [255, 255, 255, 255];
+        for key in ["albedo_map", "normal_map", "metallic_map", "roughness_map"] {
+            let handle = texture_manager::load_from_bytes(ctx, res, key, &white);
+            let tex = *res.textures.get_ref(handle);
+            res.remove(key);
+            res.register_combined(key, tex.handle, tex.view, tex.dim, sampler);
+        }
+    }
+}
+
 pub fn run(ctx: &mut Context) {
     let mut renderer = Renderer::new(320, 240, "pbr_spheres", ctx).unwrap();
-    let white: [u8; 4] = [255, 255, 255, 255];
-    let img = ctx
-        .make_image(&ImageInfo {
-            debug_name: "alb",
-            dim: [1, 1, 1],
-            format: Format::RGBA8,
-            mip_levels: 1,
-            layers: 1,
-            initial_data: Some(&white),
-        })
-        .unwrap();
-    let view = ctx
-        .make_image_view(&ImageViewInfo {
-            img,
-            ..Default::default()
-        })
-        .unwrap();
-    let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
-    renderer
-        .resources()
-        .register_combined("albedo_map", img, view, [1, 1], sampler);
-    renderer
-        .resources()
-        .register_combined("normal_map", img, view, [1, 1], sampler);
-    renderer
-        .resources()
-        .register_combined("metallic_map", img, view, [1, 1], sampler);
-    renderer
-        .resources()
-        .register_combined("roughness_map", img, view, [1, 1], sampler);
+    register_textures(ctx, renderer.resources());
 
     let mut pso = build_pbr_pipeline(ctx, renderer.render_pass(), 0);
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();


### PR DESCRIPTION
## Summary
- swap manual texture creation in `pbr_spheres` for the new `texture_manager`
- gate real texture loading behind the `gpu_tests` feature

## Testing
- `cargo test --no-run` *(failed to complete: network access restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_684dc4ee1d6c832abc798430293a640f