### PR TITLE
Add texture loading GPU test

### DIFF
--- a/tests/pbr_texture_loading.rs
+++ b/tests/pbr_texture_loading.rs
@@ -1,0 +1,108 @@
+use koji::material::*;
+use koji::renderer::*;
+use koji::texture_manager as texman;
+use dashi::*;
+use dashi::gpu;
+use dashi::utils::Handle;
+use inline_spirv::include_spirv;
+use image::{ImageBuffer, Rgba, ImageOutputFormat};
+use std::io::Cursor;
+
+fn make_vertex(pos: [f32; 3], uv: [f32; 2]) -> Vertex {
+    Vertex {
+        position: pos,
+        normal: [0.0, 0.0, 1.0],
+        tangent: [1.0, 0.0, 0.0, 1.0],
+        uv,
+        color: [1.0, 1.0, 1.0, 1.0],
+    }
+}
+
+fn quad_vertices() -> Vec<Vertex> {
+    vec![
+        make_vertex([-0.5, -0.5, 0.0], [0.0, 0.0]),
+        make_vertex([0.5, -0.5, 0.0], [1.0, 0.0]),
+        make_vertex([0.5, 0.5, 0.0], [1.0, 1.0]),
+        make_vertex([-0.5, 0.5, 0.0], [0.0, 1.0]),
+    ]
+}
+
+fn quad_indices() -> Vec<u32> {
+    vec![0, 1, 2, 2, 3, 0]
+}
+
+fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> PSO {
+    let vert: &[u32] = include_spirv!("assets/shaders/pbr.vert", vert, glsl);
+    let frag: &[u32] = include_spirv!("assets/shaders/pbr.frag", frag, glsl);
+    PipelineBuilder::new(ctx, "pbr_pipeline")
+        .vertex_shader(vert)
+        .fragment_shader(frag)
+        .render_pass(rp, subpass)
+        .depth_enable(true)
+        .cull_mode(CullMode::Back)
+        .build()
+}
+
+fn png_bytes(color: [u8; 4]) -> Vec<u8> {
+    let img: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_pixel(1, 1, Rgba(color));
+    let mut buf = Vec::new();
+    img.write_to(&mut Cursor::new(&mut buf), ImageOutputFormat::Png).unwrap();
+    buf
+}
+
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
+    let mut ctx = gpu::Context::headless(&Default::default()).unwrap();
+    let mut renderer = Renderer::new(64, 64, "pbr_tex", &mut ctx).unwrap();
+
+    let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(), 0);
+
+    let colors = [
+        [255, 0, 0, 255],
+        [0, 255, 0, 255],
+        [0, 0, 255, 255],
+        [255, 255, 0, 255],
+    ];
+
+    let keys = ["albedo_map", "normal_map", "metallic_map", "roughness_map"];
+    let mut handles = Vec::new();
+    for (key, col) in keys.iter().zip(colors.iter()) {
+        let bytes = png_bytes(*col);
+        let handle = texman::load_from_bytes(&mut ctx, renderer.resources(), key, &bytes);
+        handles.push((*key, handle));
+    }
+    let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
+    for (key, handle) in handles {
+        let tex = *renderer.resources().textures.get_ref(handle);
+        renderer.resources().register_combined(key, tex.handle, tex.view, tex.dim, sampler);
+    }
+
+    let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
+    renderer.register_pipeline_for_pass("main", pso, bgr);
+
+    let mesh = StaticMesh {
+        material_id: "pbr".into(),
+        vertices: quad_vertices(),
+        indices: Some(quad_indices()),
+        vertex_buffer: None,
+        index_buffer: None,
+        index_count: 0,
+    };
+    renderer.register_static_mesh(mesh, None, "pbr".into());
+
+    renderer.present_frame().unwrap();
+    ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn pbr_texture_loading() {
+        run();
+    }
+}


### PR DESCRIPTION
## Summary
- add ignored GPU test for loading PBR textures via `TextureManager`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ddf6e08bc832a820a756995b2e117