### PR TITLE
Add renderer TimeStats struct

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,5 +1,7 @@
 mod drawable;
 pub use drawable::*;
+mod time_stats;
+pub use time_stats::*;
 
 use crate::material::{BindlessLights, LightDesc, PSOBindGroupResources, PSO};
 use crate::utils::ResourceManager;

--- a/src/renderer/time_stats.rs
+++ b/src/renderer/time_stats.rs
@@ -1,0 +1,45 @@
+use std::time::Instant;
+
+/// Frame timing statistics for the renderer.
+///
+/// `TimeStats` tracks how much time has elapsed since
+/// the renderer started as well as the delta time between
+/// consecutive frames. All times are reported in seconds.
+pub struct TimeStats {
+    start_time: Instant,
+    prev_frame: Instant,
+    /// Seconds since [`TimeStats`] was created.
+    pub total_time: f32,
+    /// Time in seconds since the previous `update` call.
+    pub delta_time: f32,
+}
+
+impl Default for TimeStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TimeStats {
+    /// Create a new timer starting at the current instant.
+    pub fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            start_time: now,
+            prev_frame: now,
+            total_time: 0.0,
+            delta_time: 0.0,
+        }
+    }
+
+    /// Update timing statistics for the current frame.
+    ///
+    /// `total_time` becomes the elapsed time since creation and
+    /// `delta_time` is the time since the last `update`.
+    pub fn update(&mut self) {
+        let now = Instant::now();
+        self.total_time = (now - self.start_time).as_secs_f32();
+        self.delta_time = (now - self.prev_frame).as_secs_f32();
+        self.prev_frame = now;
+    }
+}

--- a/tests/time_stats.rs
+++ b/tests/time_stats.rs
@@ -1,0 +1,18 @@
+use koji::renderer::TimeStats;
+use std::time::Duration;
+
+#[test]
+fn update_tracks_elapsed_and_delta() {
+    let mut stats = TimeStats::new();
+    std::thread::sleep(Duration::from_millis(5));
+    stats.update();
+    assert!(stats.total_time > 0.0);
+    let first_total = stats.total_time;
+    let first_delta = stats.delta_time;
+    assert!(first_delta > 0.0);
+    std::thread::sleep(Duration::from_millis(5));
+    stats.update();
+    assert!(stats.total_time > first_total);
+    assert!(stats.delta_time > 0.0);
+    assert!(stats.delta_time <= stats.total_time);
+}


### PR DESCRIPTION
## Summary
- record timing information for the renderer
- expose `TimeStats` in renderer module
- implement `Default` and add a basic timing test

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684de16a1188832aa589df76d9564fcc