### PR TITLE
Add GLSL header parser

### DIFF
--- a/src/material/header_parser.rs
+++ b/src/material/header_parser.rs
@@ -1,0 +1,43 @@
+use std::collections::HashSet;
+
+/// Scan shader source (e.g. Slang or GLSL) for special Koji directives.
+///
+/// Lines referencing well known resources will cause their names (e.g. `"time"`)
+/// to be returned. The directives are parsed directly from the source code
+/// before it is compiled to SPIR-V, as comments are stripped during
+/// compilation.
+pub fn parse_headers(src: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for line in src.lines() {
+        let trimmed = line.trim();
+
+        // Handle `// koji:name` style comments
+        if let Some(pos) = trimmed.find("//") {
+            let comment = &trimmed[pos + 2..].trim();
+            if let Some(name) = comment.strip_prefix("koji:") {
+                let name = name.trim();
+                if !name.is_empty() {
+                    out.insert(name.to_string());
+                }
+            }
+        }
+    }
+
+    // Look for well known resource/function names. If present, add their
+    // short names to the result set so the caller knows which resources are
+    // required by the shader.
+    if src.contains("current_time_ms") || src.contains("gTime") {
+        out.insert("time".to_string());
+    }
+
+    if src.contains("gTex") || src.contains("gTextures") {
+        out.insert("texture".to_string());
+    }
+
+    if src.contains("gDebug") {
+        out.insert("debug".to_string());
+    }
+
+    out
+}
+

--- a/src/material/header_parser_tests.rs
+++ b/src/material/header_parser_tests.rs
@@ -1,0 +1,18 @@
+use super::*;
+use std::collections::HashSet;
+
+#[test]
+fn parse_hlsl_headers() {
+    let hlsl = "Texture2D gTex;\nfloat t = current_time_ms();";
+    let result = parse_headers(hlsl);
+    let expected: HashSet<String> = ["time", "texture"].iter().map(|s| s.to_string()).collect();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn parse_slang_headers() {
+    let slang = "float current_time_ms();\n// koji:debug";
+    let result = parse_headers(slang);
+    let expected: HashSet<String> = ["time", "debug"].iter().map(|s| s.to_string()).collect();
+    assert_eq!(result, expected);
+}

--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -5,6 +5,7 @@ pub mod pipeline_builder;
 pub mod bindless;
 pub mod bindless_lighting;
 pub mod skin_pipeline;
+pub mod header_parser;
 
 #[cfg(test)]
 mod pipeline_builder_tests;
@@ -12,12 +13,15 @@ mod pipeline_builder_tests;
 mod shader_reflection_tests;
 #[cfg(test)]
 mod material_yaml_tests;
+#[cfg(test)]
+mod header_parser_tests;
 
 pub use pipeline_builder::*;
 pub use shader_reflection::*;
 pub use bindless::*;
 pub use bindless_lighting::*;
 pub use skin_pipeline::build_skinning_pipeline;
+pub use header_parser::parse_headers;
 use crate::utils::ResourceManager;
 
 pub struct MaterialPipeline {

--- a/src/material/shader_reflection_tests.rs
+++ b/src/material/shader_reflection_tests.rs
@@ -72,3 +72,24 @@ fn shader_without_resources_has_empty_reflection() {
     assert!(info.push_constants.is_empty());
 }
 
+#[test]
+fn reflect_push_constants() {
+    let spirv: Vec<u32> = inline_spirv!(
+        r#"
+        #version 450
+        layout(push_constant) uniform Push {
+            mat4 mvp;
+        } pc;
+        void main() {}
+        "#,
+        vert
+    )
+    .to_vec();
+
+    let info = reflect_shader(&spirv);
+    assert_eq!(info.push_constants.len(), 1);
+    let pc = &info.push_constants[0];
+    assert_eq!(pc.offset, 0);
+    assert_eq!(pc.size, 64);
+}
+


### PR DESCRIPTION
## Summary
- add `header_parser` module
- expose `parse_headers`
- add minimal tests for header parsing
- add tests for Slang header parsing and SPIR-V push constant reflection

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684deeb77464832a98d7e0c02aa38565