### PR TITLE
Fix layout for pbr_spheres example

### DIFF
--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -127,11 +127,16 @@ pub fn run(ctx: &mut Context) {
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);
 
-    let (verts, inds) = make_sphere(32, 32);
-    for _ in 0..3 {
+    let (base_verts, inds) = make_sphere(32, 32);
+    let offsets = [-3.0f32, 0.0, 3.0];
+    for offset in offsets {
+        let mut verts = base_verts.clone();
+        for v in &mut verts {
+            v.position[0] += offset;
+        }
         let mesh = StaticMesh {
             material_id: "pbr".into(),
-            vertices: verts.clone(),
+            vertices: verts,
             indices: Some(inds.clone()),
             vertex_buffer: None,
             index_buffer: None,


### PR DESCRIPTION
## Summary
- offset sphere meshes so all three appear side-by-side in pbr_spheres example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f096a9b8c832ab1bd4389fe746cd4