### PR TITLE
Add shared timing shader include

### DIFF
--- a/assets/shaders/sample.frag
+++ b/assets/shaders/sample.frag
@@ -1,4 +1,5 @@
 #version 450
+#include "timing.slang"
 layout(set = 0, binding = 0) uniform sampler2D tex;
 layout(set = 0, binding = 1) uniform UBO { float v; } ubo;
 layout(location = 0) in vec2 uv;

--- a/assets/shaders/timing.slang
+++ b/assets/shaders/timing.slang
@@ -1,0 +1,2 @@
+struct TimingInfo { float currentTimeMs; float lastFrameTimeMs; };
+layout(set = 0, binding = 0) uniform TimingBuffer { TimingInfo info; } KOJI_time;

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,15 @@ Most demos compile shaders from the `assets/shaders/` directory and open a winit
 window. Heavier integrations that were originally tests (such as bindless or
 skeletal rendering) are behind the `gpu_tests` feature flag.
 
+The `assets/shaders/timing.slang` file defines a uniform block providing frame
+timing information. To access it in your own shader add:
+
+```glsl
+#include "timing.slang"
+```
+
+This makes a `KOJI_time` uniform available in set `0`, binding `0`.
+
 ```
 cargo run --example sample                        # run the triangle sample
 cargo run --features gpu_tests --example text2d   # run an example requiring gpu_tests

--- a/src/material/shader_reflection_tests.rs
+++ b/src/material/shader_reflection_tests.rs
@@ -72,3 +72,12 @@ fn shader_without_resources_has_empty_reflection() {
     assert!(info.push_constants.is_empty());
 }
 
+#[test]
+fn include_file_uniform_reflected() {
+    use inline_spirv::include_spirv;
+    let spirv: &[u32] = include_spirv!("tests/data/test_timing.frag", frag, glsl);
+    let info = reflect_shader(spirv);
+    let set0 = info.bindings.get(&0).expect("missing set 0");
+    assert!(set0.iter().any(|b| b.name == "KOJI_time" || b.members.iter().any(|m| m.0 == "KOJI_time")));
+}
+

--- a/tests/data/test_timing.frag
+++ b/tests/data/test_timing.frag
@@ -1,0 +1,3 @@
+#version 450
+#include "../../assets/shaders/timing.slang"
+void main() {}


### PR DESCRIPTION
## Summary
- add `timing.slang` with `KOJI_time` uniform block
- update sample fragment shader to include the new header
- document shader include usage in example README
- test shader reflection handles `timing.slang` include

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854660ff364832a9eb2a8e5eb152060