### PR TITLE
Document automatic KOJI_time buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ cargo build
 cargo test
 ```
 
+## Frame Timing
+
+Shaders that reference the `KOJI_time` uniform automatically receive a timing
+buffer when their pipeline is built. The helper file
+`assets/shaders/timing.slang` defines the uniform block and can be included with
+
+```glsl
+#include "timing.slang"
+```
+
+No extra resource registration is necessary.
+
 ## Sample Binaries
 
 Example programs live under the `examples/` directory and can be run with
@@ -37,3 +49,7 @@ Example programs live under the `examples/` directory and can be run with
 window system. Some of the heavier demos are gated behind the `gpu_tests`
 feature flag. See [examples/README.md](examples/README.md) for a description of
 each example and exact commands.
+
+## Contributing
+
+Before submitting a pull request, run `cargo test` and ensure it completes successfully.

--- a/assets/shaders/sample.frag
+++ b/assets/shaders/sample.frag
@@ -1,10 +1,12 @@
 #version 450
 #include "timing.slang"
-layout(set = 0, binding = 0) uniform sampler2D tex;
-layout(set = 0, binding = 1) uniform UBO { float v; } ubo;
+layout(set = 0, binding = 1) uniform sampler2D tex;
+layout(set = 0, binding = 2) uniform UBO { float v; } ubo;
 layout(location = 0) in vec2 uv;
 layout(location = 0) out vec4 outColor;
 void main() {
+    float t = KOJI_time.info.currentTimeMs / 1000.0;
+    vec3 dynamic = vec3(0.5 + 0.5 * sin(t), 0.5 + 0.5 * cos(t), 0.5);
     vec4 color = texture(tex, uv);
-    outColor = mix(color, vec4(0.0, 1.0, 0.0, 1.0), ubo.v);
+    outColor = mix(color, vec4(dynamic, 1.0), ubo.v);
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,13 +8,16 @@ window. Heavier integrations that were originally tests (such as bindless or
 skeletal rendering) are behind the `gpu_tests` feature flag.
 
 The `assets/shaders/timing.slang` file defines a uniform block providing frame
-timing information. To access it in your own shader add:
+timing information. Any shader referencing the `KOJI_time` uniform will
+automatically receive a timing buffer when its pipeline is built.
+To access this uniform add:
 
 ```glsl
 #include "timing.slang"
 ```
 
-This makes a `KOJI_time` uniform available in set `0`, binding `0`.
+This makes a `KOJI_time` uniform available in set `0`, binding `0` without any
+additional setup.
 
 ```
 cargo run --example sample                        # run the triangle sample
@@ -23,7 +26,7 @@ cargo run --features gpu_tests --example text2d   # run an example requiring gpu
 
 ## Available Examples
 
-- **sample** – draw a single triangle
+- **sample** – draw a single triangle and animate its color using `KOJI_time`
 - **deferred_sample** – basic deferred rendering
 - **shadow_sample** – cascaded shadow maps
 - **pbr_spheres** – grid of spheres with PBR shading

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -1,6 +1,8 @@
 use dashi::utils::*;
 use dashi::*;
 use koji::*;
+use bytemuck;
+use std::time::Instant;
 use winit::event::{Event, WindowEvent, KeyboardInput, ElementState, VirtualKeyCode};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::platform::run_return::EventLoopExtRunReturn;
@@ -86,16 +88,26 @@ pub fn render_sample_model(ctx: &mut Context, rp: Handle<RenderPass>, targets: &
     )
     .to_vec();
 
+    // ==== NEW: Use ResourceManager to bind resources by shader name ====
+    let mut resources = ResourceManager::new(ctx, 4096).unwrap();
+
     let mut pso = PipelineBuilder::new(ctx, "sample_pso")
         .vertex_shader(&vert_spirv)
         .fragment_shader(&frag_spirv)
         .render_pass(rp, 0)
-        .build();
+        .build_with_resources(&mut resources);
 
-    // ==== NEW: Use ResourceManager to bind resources by shader name ====
-    let mut resources = ResourceManager::new(ctx, 4096).unwrap();
     resources.register_combined("tex", img, view, [1, 1], sampler);
     resources.register_variable("ubo", ctx, uniform_value);
+
+    // Retrieve the automatically injected timing buffer
+    let time_buf = match resources.get("time") {
+        Some(ResourceBinding::Uniform(h)) => *h,
+        _ => panic!("time buffer missing"),
+    };
+
+    let mut start = Instant::now();
+    let mut prev = start;
 
     let bind_group = pso.create_bind_group(0, &resources).unwrap();
 
@@ -122,6 +134,18 @@ pub fn render_sample_model(ctx: &mut Context, rp: Handle<RenderPass>, targets: &
         }
         if should_exit {
             break 'running;
+        }
+
+        let now = Instant::now();
+        let total = (now - start).as_secs_f32() * 1000.0;
+        let delta = (now - prev).as_secs_f32() * 1000.0;
+        prev = now;
+        let data = [total, delta];
+        {
+            let slice: &mut [u8] = ctx.map_buffer_mut(time_buf).unwrap();
+            let bytes = bytemuck::bytes_of(&data);
+            slice[..bytes.len()].copy_from_slice(bytes);
+            ctx.unmap_buffer(time_buf).unwrap();
         }
 
         let (img, acquire_sem, _img_idx, _ok) = ctx.acquire_new_image(&mut display).unwrap();


### PR DESCRIPTION
## Summary
- document automatic time buffer injection
- animate example with `KOJI_time`
- mention running `cargo test` before PRs
- fix descriptor bindings in sample shader
- register default time buffer when building the sample
- update sample to advance timing

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685470d1f800832a8088e86f1ae65a1e