### PR TITLE
Add PBR sphere shaders

### DIFF
--- a/assets/shaders/pbr_spheres.frag
+++ b/assets/shaders/pbr_spheres.frag
@@ -1,0 +1,83 @@
+#version 450
+
+layout(location = 0) in vec3 vWorldPos;
+layout(location = 1) in vec3 vNormal;
+layout(location = 2) in vec2 vUV;
+
+layout(set = 0, binding = 0) uniform sampler2D albedo_map;
+layout(set = 0, binding = 1) uniform sampler2D normal_map;
+layout(set = 0, binding = 2) uniform sampler2D metallic_map;
+layout(set = 0, binding = 3) uniform sampler2D roughness_map;
+
+layout(set = 0, binding = 4) uniform Camera {
+    mat4 view_proj;
+    vec3 cam_pos;
+};
+
+struct Light {
+    vec3 position;
+    float intensity;
+};
+
+layout(set = 0, binding = 5) uniform SceneLight { Light light; };
+
+layout(location = 0) out vec4 outColor;
+
+vec3 fresnelSchlick(float cosTheta, vec3 F0) {
+    return F0 + (1.0 - F0) * pow(1.0 - cosTheta, 5.0);
+}
+
+float distributionGGX(vec3 N, vec3 H, float roughness) {
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float NdotH = max(dot(N, H), 0.0);
+    float NdotH2 = NdotH * NdotH;
+    float denom = (NdotH2 * (a2 - 1.0) + 1.0);
+    return a2 / (3.141592 * denom * denom);
+}
+
+float geometrySchlickGGX(float NdotV, float roughness) {
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return NdotV / (NdotV * (1.0 - k) + k);
+}
+
+float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness) {
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotL = max(dot(N, L), 0.0);
+    return geometrySchlickGGX(NdotV, roughness) * geometrySchlickGGX(NdotL, roughness);
+}
+
+void main() {
+    vec3 albedo = pow(texture(albedo_map, vUV).rgb, vec3(2.2));
+    vec3 normalSample = texture(normal_map, vUV).xyz * 2.0 - 1.0;
+    vec3 N = normalize(normalSample);
+    vec3 V = normalize(cam_pos - vWorldPos);
+    vec3 L = normalize(light.position - vWorldPos);
+    vec3 H = normalize(V + L);
+
+    float roughness = texture(roughness_map, vUV).r;
+    float metallic = texture(metallic_map, vUV).r;
+
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+    vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
+
+    float NDF = distributionGGX(N, H, roughness);
+    float G = geometrySmith(N, V, L, roughness);
+
+    float NdotL = max(dot(N, L), 0.0);
+    float NdotV = max(dot(N, V), 0.0);
+
+    vec3 numerator = NDF * G * F;
+    float denom = 4.0 * NdotV * NdotL + 0.001;
+    vec3 specular = numerator / denom;
+
+    vec3 kS = F;
+    vec3 kD = (1.0 - kS) * (1.0 - metallic);
+
+    vec3 diffuse = kD * albedo / 3.141592;
+    vec3 color = (diffuse + specular) * NdotL * light.intensity;
+
+    color = pow(color, vec3(1.0 / 2.2));
+    outColor = vec4(color, 1.0);
+}

--- a/assets/shaders/pbr_spheres.vert
+++ b/assets/shaders/pbr_spheres.vert
@@ -1,0 +1,24 @@
+#version 450
+layout(set = 0, binding = 4) uniform Camera {
+    mat4 view_proj;
+    vec3 cam_pos;
+};
+
+layout(location = 0) in vec3 inPos;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec4 inTangent;
+layout(location = 3) in vec2 inUV;
+layout(location = 4) in vec4 inColor;
+
+layout(location = 0) out vec3 vWorldPos;
+layout(location = 1) out vec3 vNormal;
+layout(location = 2) out vec2 vUV;
+
+void main() {
+    mat4 model = mat4(1.0);
+    vec4 world = model * vec4(inPos, 1.0);
+    vWorldPos = world.xyz;
+    vNormal = mat3(model) * inNormal;
+    vUV = inUV;
+    gl_Position = view_proj * world;
+}


### PR DESCRIPTION
## Summary
- add vertex shader with camera uniforms for PBR spheres
- add fragment shader that samples albedo, normal, metallic and roughness maps
- include light uniform for full PBR lighting

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6856400487d0832a9d96d156e1c2155a