### PR TITLE
Update pbr_spheres camera and light

### DIFF
--- a/examples/custom_pass/bin.rs
+++ b/examples/custom_pass/bin.rs
@@ -66,7 +66,7 @@ subpasses:
     renderer.register_static_mesh(mesh, None, "color".into());
 
     // Render loop - nothing changes per frame in this simple sample
-    renderer.render_loop(|_r| {
+    renderer.render_loop(|_r, _event| {
         // No dynamic updates
     });
 }

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -79,7 +79,7 @@ pub fn run(ctx: &mut Context) {
     };
     renderer.register_static_mesh(mesh, None, "color".into());
 
-    renderer.render_loop(|_r| {});
+    renderer.render_loop(|_r, _event| {});
 }
 
 pub fn main() {

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -406,6 +406,11 @@ impl<'a> PipelineBuilder<'a> {
         for (set, binds) in vert_info.bindings.into_iter().chain(frag_info.bindings) {
             combined.entry(set).or_default().extend(binds);
         }
+        // Deduplicate descriptors that appear in multiple shader stages
+        for binds in combined.values_mut() {
+            binds.sort_by_key(|b| b.binding);
+            binds.dedup_by(|a, b| a.binding == b.binding && a.ty == b.ty);
+        }
 
         let mut desc_map = HashMap::new();
         let mut bg_layouts: [Option<Handle<BindGroupLayout>>; 4] = [None, None, None, None];

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -1,5 +1,6 @@
 use koji::material::*;
 use koji::renderer::*;
+use koji::utils::ResourceManager;
 use dashi::*;
 
 use inline_spirv::include_spirv;
@@ -26,7 +27,12 @@ fn quad_vertices() -> Vec<Vertex> {
 
 fn quad_indices() -> Vec<u32> { vec![0,1,2,2,3,0] }
 
-fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> PSO {
+fn build_pbr_pipeline(
+    ctx: &mut Context,
+    rp: Handle<RenderPass>,
+    subpass: u32,
+    res: &mut ResourceManager,
+) -> PSO {
     let vert: &[u32] = include_spirv!("assets/shaders/pbr.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("assets/shaders/pbr.frag", frag, glsl);
     PipelineBuilder::new(ctx, "pbr_pipeline")
@@ -35,7 +41,7 @@ fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -
         .render_pass(rp, subpass)
         .depth_enable(true)
         .cull_mode(CullMode::Back)
-        .build()
+        .build_with_resources(res)
 }
 
 #[cfg(feature = "gpu_tests")]
@@ -44,7 +50,7 @@ pub fn run() {
     let mut ctx = Context::new(&ContextInfo{ device }).unwrap();
     let mut renderer = Renderer::new(320,240,"pbr", &mut ctx).expect("renderer");
 
-    let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(),0);
+    let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(), 0, renderer.resources());
 
     // register textures before creating bind groups
     let white: [u8;4] = [255,255,255,255];

--- a/tests/pbr_texture_loading.rs
+++ b/tests/pbr_texture_loading.rs
@@ -1,6 +1,7 @@
 use koji::material::*;
 use koji::renderer::*;
 use koji::texture_manager as texman;
+use koji::utils::ResourceManager;
 use dashi::*;
 use dashi::gpu;
 use dashi::utils::Handle;
@@ -31,7 +32,12 @@ fn quad_indices() -> Vec<u32> {
     vec![0, 1, 2, 2, 3, 0]
 }
 
-fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> PSO {
+fn build_pbr_pipeline(
+    ctx: &mut Context,
+    rp: Handle<RenderPass>,
+    subpass: u32,
+    res: &mut ResourceManager,
+) -> PSO {
     let vert: &[u32] = include_spirv!("assets/shaders/pbr.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("assets/shaders/pbr.frag", frag, glsl);
     PipelineBuilder::new(ctx, "pbr_pipeline")
@@ -40,7 +46,7 @@ fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -
         .render_pass(rp, subpass)
         .depth_enable(true)
         .cull_mode(CullMode::Back)
-        .build()
+        .build_with_resources(res)
 }
 
 fn png_bytes(color: [u8; 4]) -> Vec<u8> {
@@ -55,7 +61,7 @@ pub fn run() {
     let mut ctx = gpu::Context::headless(&Default::default()).unwrap();
     let mut renderer = Renderer::new(64, 64, "pbr_tex", &mut ctx).unwrap();
 
-    let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(), 0);
+    let mut pso = build_pbr_pipeline(&mut ctx, renderer.render_pass(), 0, renderer.resources());
 
     let colors = [
         [255, 0, 0, 255],

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -125,7 +125,7 @@ fn render_triangle_and_cube() {
     renderer.register_static_mesh(cube_mesh, None, "color".into());
 
     // Main loop: just draw both objects with same pipeline/PSO/bind group
-    renderer.render_loop(|_r| {
+    renderer.render_loop(|_r, _event| {
         // Nothing to update per frame in this simple test
     });
 }


### PR DESCRIPTION
## Summary
- pass winit events through `Renderer::render_loop`
- rotate the camera and handle arrow keys in `pbr_spheres` example
- update samples and tests for new callback signature
- deduplicate descriptor bindings when building pipelines
- **fix dedup logic to preserve bindings**
- build the pbr pipeline using registered resources

## Testing
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_6856d0d1aad0832a8658a7fb39e9dc3e