### PR TITLE
Add depth clear control to renderer

### DIFF
--- a/examples/custom_pass/bin.rs
+++ b/examples/custom_pass/bin.rs
@@ -27,6 +27,7 @@ subpasses:
     let builder = RenderPassBuilder::from_yaml(config);
 
     let mut renderer = Renderer::with_render_pass(640, 480, ctx, builder).unwrap();
+    renderer.set_clear_depth(1.0);
 
     // Shaders for a colored triangle
     let vert = include_spirv!("assets/shaders/test_triangle.vert", vert);

--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -153,6 +153,7 @@ pub fn run(ctx: &mut Context) {
         .subpass("main", ["color"], &[] as &[&str]);
 
     let mut renderer = Renderer::with_render_pass(1920, 1080, ctx, builder).unwrap();
+    renderer.set_clear_depth(1.0);
     register_textures(ctx, renderer.resources());
 
     let mut pso = build_pbr_pipeline(ctx, renderer.render_pass(), 0);

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -5,6 +5,7 @@ use koji::renderer::*;
 
 pub fn run(ctx: &mut Context) {
     let mut renderer = Renderer::new(640, 480, "sample", ctx).unwrap();
+    renderer.set_clear_depth(1.0);
 
     let vert: &[u32] = include_spirv!("assets/shaders/sample.vert", vert);
     let frag: &[u32] = include_spirv!("assets/shaders/sample.frag", frag);


### PR DESCRIPTION
## Summary
- extend `Renderer` with a `clear_depth` field
- configure attachments with stored clear color/depth
- update color and depth clear methods
- use `set_clear_depth` in example programs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68585371c920832a8f30f3b383a8ba17