### PR TITLE
Remove include! usage in examples

### DIFF
--- a/examples/bindless_lighting/bin.rs
+++ b/examples/bindless_lighting/bin.rs
@@ -1,9 +1,97 @@
+use dashi::*;
+use inline_spirv::inline_spirv;
+use koji::material::*;
+use koji::renderer::*;
+
+fn vert() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(location=0) in vec3 pos;
+        void main(){ gl_Position=vec4(pos,1.0); }",
+        vert
+    )
+    .to_vec()
+}
+
+fn frag() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(set=0,binding=0) buffer Lights { vec4 data[]; };
+        layout(location=0) out vec4 o;
+        void main(){ o = data.length()>0 ? data[0] : vec4(1.0); }",
+        frag
+    )
+    .to_vec()
+}
+
 #[cfg(feature = "gpu_tests")]
-mod bindless_lighting {
-    include!("../../tests/bindless_lighting.rs");
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "lights", ctx).unwrap();
+
+    let mut pso = PipelineBuilder::new(ctx, "lights")
+        .vertex_shader(&vert())
+        .fragment_shader(&frag())
+        .render_pass(renderer.render_pass(), 0)
+        .build();
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_pipeline_for_pass("main", pso, bgr);
+
+    let mut lights = BindlessLights::new();
+    let light = LightDesc {
+        position: [0.0, 0.0, 0.0],
+        intensity: 1.0,
+        color: [1.0, 1.0, 1.0],
+        range: 1.0,
+        direction: [0.0, 0.0, -1.0],
+        _pad: 0,
+    };
+    lights.add_light(ctx, renderer.resources(), light);
+    lights.register(renderer.resources());
+
+    let mesh = StaticMesh {
+        material_id: "lighting".into(),
+        vertices: vec![
+            Vertex {
+                position: [-0.5, -0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [0.0, 0.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+            Vertex {
+                position: [0.5, -0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [1.0, 0.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+            Vertex {
+                position: [0.0, 0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [0.5, 1.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+        ],
+        indices: None,
+        vertex_buffer: None,
+        index_buffer: None,
+        index_count: 0,
+    };
+    renderer.register_static_mesh(mesh, None, "lighting".into());
+
+    renderer.present_frame().unwrap();
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
-    bindless_lighting::run();
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
 }

--- a/examples/bindless_rendering/bin.rs
+++ b/examples/bindless_rendering/bin.rs
@@ -1,9 +1,113 @@
+use inline_spirv::inline_spirv;
+use koji::material::*;
+use koji::renderer::*;
+use dashi::*;
+
+fn simple_vert() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(location=0) in vec3 pos;
+        void main(){ gl_Position = vec4(pos,1.0); }",
+        vert
+    )
+    .to_vec()
+}
+
+fn simple_frag() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(location=0) out vec4 o;
+        void main(){ o = vec4(1.0); }",
+        frag
+    )
+    .to_vec()
+}
+
 #[cfg(feature = "gpu_tests")]
-mod bindless_rendering {
-    include!("../../tests/bindless_rendering.rs");
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "bindless", ctx).unwrap();
+
+    let vert = simple_vert();
+    let frag = simple_frag();
+    let mut pso = PipelineBuilder::new(ctx, "bindless")
+        .vertex_shader(&vert)
+        .fragment_shader(&frag)
+        .render_pass(renderer.render_pass(), 0)
+        .build();
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_pipeline_for_pass("main", pso, bgr);
+
+    let mut bindless = BindlessData::new();
+    let tex_data: [u8; 4] = [255, 0, 0, 255];
+    let img = ctx
+        .make_image(&ImageInfo {
+            debug_name: "t",
+            dim: [1, 1, 1],
+            format: Format::RGBA8,
+            mip_levels: 1,
+            layers: 1,
+            initial_data: Some(&tex_data),
+        })
+        .unwrap();
+    let view = ctx
+        .make_image_view(&ImageViewInfo {
+            img,
+            ..Default::default()
+        })
+        .unwrap();
+    let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
+    bindless.add_texture(img, view, sampler, [1, 1]);
+    #[repr(C)]
+    #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+    struct Dummy {
+        val: f32,
+    }
+    let _ = bindless.add_material(ctx, renderer.resources(), Dummy { val: 1.0 });
+    bindless.register(renderer.resources());
+
+    let mesh = StaticMesh {
+        material_id: "bindless".into(),
+        vertices: vec![
+            Vertex {
+                position: [0.0, -0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [0.0, 0.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+            Vertex {
+                position: [0.5, 0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [1.0, 1.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+            Vertex {
+                position: [-0.5, 0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [0.0, 1.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+        ],
+        indices: None,
+        vertex_buffer: None,
+        index_buffer: None,
+        index_count: 0,
+    };
+    renderer.register_static_mesh(mesh, None, "bindless".into());
+    renderer.present_frame().unwrap();
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
-    bindless_rendering::run();
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
 }

--- a/examples/pbr_renderer/bin.rs
+++ b/examples/pbr_renderer/bin.rs
@@ -1,9 +1,107 @@
+use dashi::*;
+use inline_spirv::include_spirv;
+use koji::material::*;
+use koji::material::pipeline_builder::PipelineBuilder;
+use koji::renderer::*;
+use dashi::utils::Handle;
+
+fn make_vertex(pos: [f32; 3], uv: [f32; 2]) -> Vertex {
+    Vertex {
+        position: pos,
+        normal: [0.0, 0.0, 1.0],
+        tangent: [1.0, 0.0, 0.0, 1.0],
+        uv,
+        color: [1.0, 1.0, 1.0, 1.0],
+    }
+}
+
+fn quad_vertices() -> Vec<Vertex> {
+    vec![
+        make_vertex([-0.5, -0.5, 0.0], [0.0, 0.0]),
+        make_vertex([0.5, -0.5, 0.0], [1.0, 0.0]),
+        make_vertex([0.5, 0.5, 0.0], [1.0, 1.0]),
+        make_vertex([-0.5, 0.5, 0.0], [0.0, 1.0]),
+    ]
+}
+
+fn quad_indices() -> Vec<u32> {
+    vec![0, 1, 2, 2, 3, 0]
+}
+
+fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> PSO {
+    let vert: &[u32] = include_spirv!("assets/shaders/pbr.vert", vert, glsl);
+    let frag: &[u32] = include_spirv!("assets/shaders/pbr.frag", frag, glsl);
+    PipelineBuilder::new(ctx, "pbr_pipeline")
+        .vertex_shader(vert)
+        .fragment_shader(frag)
+        .render_pass(rp, subpass)
+        .depth_enable(true)
+        .cull_mode(CullMode::Back)
+        .build()
+}
+
 #[cfg(feature = "gpu_tests")]
-mod pbr_renderer {
-    include!("../../tests/pbr_renderer.rs");
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "pbr", ctx).expect("renderer");
+
+    let mut pso = build_pbr_pipeline(ctx, renderer.render_pass(), 0);
+
+    let white: [u8; 4] = [255, 255, 255, 255];
+    let img = ctx
+        .make_image(&ImageInfo {
+            debug_name: "alb",
+            dim: [1, 1, 1],
+            format: Format::RGBA8,
+            mip_levels: 1,
+            layers: 1,
+            initial_data: Some(&white),
+        })
+        .unwrap();
+    let view = ctx
+        .make_image_view(&ImageViewInfo {
+            img,
+            ..Default::default()
+        })
+        .unwrap();
+    let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
+    renderer
+        .resources()
+        .register_combined("albedo_map", img, view, [1, 1], sampler);
+    renderer
+        .resources()
+        .register_combined("normal_map", img, view, [1, 1], sampler);
+    renderer
+        .resources()
+        .register_combined("metallic_map", img, view, [1, 1], sampler);
+    renderer
+        .resources()
+        .register_combined("roughness_map", img, view, [1, 1], sampler);
+
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_pipeline_for_pass("main", pso, bgr);
+
+    let mesh = StaticMesh {
+        material_id: "pbr".into(),
+        vertices: quad_vertices(),
+        indices: Some(quad_indices()),
+        vertex_buffer: None,
+        index_buffer: None,
+        index_count: 0,
+    };
+    renderer.register_static_mesh(mesh, None, "pbr".into());
+
+    renderer.present_frame().unwrap();
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
-    pbr_renderer::run();
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
 }

--- a/examples/skeletal_animation/bin.rs
+++ b/examples/skeletal_animation/bin.rs
@@ -1,9 +1,42 @@
+use dashi::*;
+use koji::animation::clip::AnimationPlayer;
+use koji::animation::Animator;
+use koji::gltf::{load_scene, MeshData};
+use koji::material::*;
+use koji::renderer::*;
+
 #[cfg(feature = "gpu_tests")]
-mod skeletal_animation {
-    include!("../../tests/skeletal_animation.rs");
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "anim", ctx).unwrap();
+
+    let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
+    let mesh = match &scene.meshes[0].mesh {
+        MeshData::Skeletal(m) => m.clone(),
+        _ => panic!("expected skel"),
+    };
+    let clip = scene.animations[0].clone();
+    let player = AnimationPlayer::new(clip);
+    let animator = Animator::new(mesh.skeleton.clone());
+    let instance = SkeletalInstance::with_player(ctx, animator, player).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
+
+    let mut pso = build_skinning_pipeline(ctx, renderer.render_pass(), 0);
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_skeletal_pso(pso, bgr);
+
+    renderer.play_animation(0, 0, 0.5);
+    renderer.present_frame().unwrap();
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
-    skeletal_animation::run();
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
 }

--- a/examples/skeletal_renderer/bin.rs
+++ b/examples/skeletal_renderer/bin.rs
@@ -1,12 +1,70 @@
+use glam::Mat4;
+use koji::animation::Animator;
+use koji::gltf::{load_scene, MeshData};
+use koji::material::*;
+use koji::renderer::*;
+use dashi::*;
+
 #[cfg(feature = "gpu_tests")]
-mod skeletal_renderer {
-    include!("../../tests/skeletal_renderer.rs");
+fn run_simple_skeleton(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "skin", ctx).unwrap();
+
+    let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
+    let mesh = match &scene.meshes[0].mesh {
+        MeshData::Skeletal(m) => m.clone(),
+        _ => panic!("expected skeletal mesh"),
+    };
+    let bone_count = mesh.skeleton.bone_count();
+    let instance = SkeletalInstance::new(ctx, Animator::new(mesh.skeleton.clone())).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
+
+    let mut pso = build_skinning_pipeline(ctx, renderer.render_pass(), 0);
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_skeletal_pso(pso, bgr);
+
+    let mats = vec![Mat4::IDENTITY; bone_count];
+    renderer.update_skeletal_bones(0, 0, &mats);
+    renderer.present_frame().unwrap();
+}
+
+#[cfg(feature = "gpu_tests")]
+fn run_update_bones_twice(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "skin", ctx).unwrap();
+
+    let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
+    let mesh = match &scene.meshes[0].mesh {
+        MeshData::Skeletal(m) => m.clone(),
+        _ => panic!("expected skeletal mesh"),
+    };
+    let bone_count = mesh.skeleton.bone_count();
+    let instance = SkeletalInstance::new(ctx, Animator::new(mesh.skeleton.clone())).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
+
+    let mut pso = build_skinning_pipeline(ctx, renderer.render_pass(), 0);
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_skeletal_pso(pso, bgr);
+
+    let mats = vec![Mat4::IDENTITY; bone_count];
+    renderer.update_skeletal_bones(0, 0, &mats);
+    renderer.update_skeletal_bones(0, 0, &mats);
+    renderer.present_frame().unwrap();
+}
+
+#[cfg(feature = "gpu_tests")]
+pub fn run(ctx: &mut Context) {
+    run_simple_skeleton(ctx);
+    run_update_bones_twice(ctx);
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
     {
-        skeletal_renderer::run_simple_skeleton();
-        skeletal_renderer::run_update_bones_twice();
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
     }
 }

--- a/examples/skinned_mesh_render/bin.rs
+++ b/examples/skinned_mesh_render/bin.rs
@@ -1,9 +1,41 @@
+use glam::Mat4;
+use koji::animation::Animator;
+use koji::gltf::{load_scene, MeshData};
+use koji::material::*;
+use koji::renderer::*;
+use dashi::*;
+
 #[cfg(feature = "gpu_tests")]
-mod skinned_mesh_render {
-    include!("../../tests/skinned_mesh_render.rs");
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "skin", ctx).unwrap();
+
+    let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
+    let mesh = match &scene.meshes[0].mesh {
+        MeshData::Skeletal(m) => m.clone(),
+        _ => panic!("expected skel"),
+    };
+    let bone_count = mesh.skeleton.bone_count();
+    let instance = SkeletalInstance::new(ctx, Animator::new(mesh.skeleton.clone())).unwrap();
+    renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
+
+    let mut pso = build_skinning_pipeline(ctx, renderer.render_pass(), 0);
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_skeletal_pso(pso, bgr);
+
+    let mats = vec![Mat4::IDENTITY; bone_count];
+    renderer.update_skeletal_bones(0, 0, &mats);
+    renderer.present_frame().unwrap();
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
-    skinned_mesh_render::run();
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
 }

--- a/examples/static_movement/bin.rs
+++ b/examples/static_movement/bin.rs
@@ -1,9 +1,101 @@
+use dashi::*;
+use inline_spirv::inline_spirv;
+use koji::material::*;
+use koji::renderer::*;
+
+fn vert() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(location=0) in vec3 pos;
+        void main(){ gl_Position = vec4(pos,1.0); }",
+        vert
+    )
+    .to_vec()
+}
+
+fn frag() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(location=0) out vec4 o;
+        void main(){ o=vec4(1.0); }",
+        frag
+    )
+    .to_vec()
+}
+
+fn make_vertex(pos: [f32; 3]) -> Vertex {
+    Vertex {
+        position: pos,
+        normal: [0.0, 0.0, 1.0],
+        tangent: [1.0, 0.0, 0.0, 1.0],
+        uv: [0.0, 0.0],
+        color: [1.0, 1.0, 1.0, 1.0],
+    }
+}
+
 #[cfg(feature = "gpu_tests")]
-mod static_movement {
-    include!("../../tests/static_movement.rs");
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "move", ctx).unwrap();
+
+    let mut pso = PipelineBuilder::new(ctx, "move_pso")
+        .vertex_shader(&vert())
+        .fragment_shader(&frag())
+        .render_pass(renderer.render_pass(), 0)
+        .build();
+    let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
+    renderer.register_pipeline_for_pass("main", pso, bgr);
+
+    let mesh = StaticMesh {
+        material_id: "default".into(),
+        vertices: vec![
+            Vertex {
+                position: [-0.5, -0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [0.0, 0.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+            Vertex {
+                position: [0.5, -0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [1.0, 0.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+            Vertex {
+                position: [0.0, 0.5, 0.0],
+                normal: [0.0, 0.0, 1.0],
+                tangent: [1.0, 0.0, 0.0, 1.0],
+                uv: [0.5, 1.0],
+                color: [1.0, 1.0, 1.0, 1.0],
+            },
+        ],
+        indices: None,
+        vertex_buffer: None,
+        index_buffer: None,
+        index_count: 0,
+    };
+    renderer.register_static_mesh(mesh, None, "default".into());
+
+    let new_verts = vec![
+        make_vertex([-0.25, -0.25, 0.0]),
+        make_vertex([0.75, -0.25, 0.0]),
+        make_vertex([0.25, 0.75, 0.0]),
+    ];
+    renderer.update_static_mesh(0, &new_verts);
+
+    renderer.present_frame().unwrap();
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
-    static_movement::run();
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
 }

--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -1,9 +1,66 @@
+use dashi::*;
+use inline_spirv::include_spirv;
+use koji::material::pipeline_builder::PipelineBuilder;
+use koji::renderer::*;
+use koji::text::*;
+
+fn load_system_font() -> Vec<u8> {
+    #[cfg(target_os = "windows")]
+    const CANDIDATES: &[&str] = &["C:/Windows/Fonts/arial.ttf", "C:/Windows/Fonts/segoeui.ttf"];
+    #[cfg(target_os = "linux")]
+    const CANDIDATES: &[&str] = &[
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+    ];
+    for path in CANDIDATES {
+        if let Ok(bytes) = std::fs::read(path) {
+            return bytes;
+        }
+    }
+    panic!("Could not locate a system font");
+}
+
+fn make_vert() -> Vec<u32> {
+    include_spirv!("assets/shaders/text.vert", vert).to_vec()
+}
+
+fn make_frag() -> Vec<u32> {
+    include_spirv!("assets/shaders/text.frag", frag).to_vec()
+}
+
 #[cfg(feature = "gpu_tests")]
-mod text2d {
-    include!("../../tests/text2d.rs");
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(320, 240, "text", ctx).expect("renderer");
+
+    let vert_spv = make_vert();
+    let frag_spv = make_frag();
+    let mut pso = PipelineBuilder::new(ctx, "text_pso")
+        .vertex_shader(&vert_spv)
+        .fragment_shader(&frag_spv)
+        .render_pass(renderer.render_pass(), 0)
+        .build();
+    let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
+    renderer.register_pipeline_for_pass("main", pso, bgr);
+
+    let font_bytes = load_system_font();
+    let text = TextRenderer2D::new(&font_bytes);
+    let dim = text.upload_text_texture(ctx, renderer.resources(), "glyph_tex", "Hello", 32.0);
+    let mesh = text.make_quad(dim, [-0.5, 0.5]);
+    renderer.register_text_mesh(mesh);
+
+    renderer.present_frame().unwrap();
 }
 
 fn main() {
     #[cfg(feature = "gpu_tests")]
-    text2d::run();
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
 }


### PR DESCRIPTION
## Summary
- replace `include!` macros in example binaries with standalone code
- keep example structure consistent with sample and pbr_spheres

## Testing
- `cargo test` *(fails: timed out during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6858c50f439c832a8f03e0f965eca043