### PR TITLE
Remove unused mut in build_internal

### DIFF
--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -395,7 +395,7 @@ impl<'a> PipelineBuilder<'a> {
     }
 
     fn build_internal(
-        mut self,
+        self,
         res: Option<&mut ResourceManager>,
     ) -> Result<PSO, PipelineError> {
         let rp = self


### PR DESCRIPTION
## Summary
- remove `mut` from `build_internal` receiver parameter in `pipeline_builder.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858bf365a40832aa5e5505c383adb68