### PR TITLE
Fix test imports in drawable

### DIFF
--- a/src/renderer/drawable.rs
+++ b/src/renderer/drawable.rs
@@ -173,7 +173,6 @@ impl SkeletalInstance {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dashi::*;
     use serial_test::serial;
     use crate::animation::Bone;
 


### PR DESCRIPTION
## Summary
- remove redundant `use dashi::*` from `drawable` test module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858bf39d640832a8d3c73ba61f2158f