### PR TITLE
Remove unnecessary mut from render targets

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -78,7 +78,7 @@ impl Renderer {
         })?;
 
         let builder = builder.extent([width, height]);
-        let (render_pass, mut targets, _attachments) = builder.build_with_images(&mut ctx)?;
+        let (render_pass, targets, _attachments) = builder.build_with_images(&mut ctx)?;
 
         assert!(render_pass.valid());
 


### PR DESCRIPTION
## Summary
- clean up `Renderer::with_render_pass` by dropping `mut` from `targets`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858bf384020832a92eb1554b45940ec