### PR TITLE
Clean up unused imports in pbr example

### DIFF
--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -8,8 +8,6 @@ use koji::texture_manager;
 use koji::utils::{ResourceManager, ResourceBinding};
 use glam::*;
 use winit::event::{Event, WindowEvent, KeyboardInput, ElementState, VirtualKeyCode};
-use winit::event_loop::ControlFlow;
-use winit::platform::run_return::EventLoopExtRunReturn;
 #[cfg(feature = "gpu_tests")]
 use std::path::Path;
 

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -395,7 +395,7 @@ impl<'a> PipelineBuilder<'a> {
     }
 
     fn build_internal(
-        mut self,
+        self,
         res: Option<&mut ResourceManager>,
     ) -> Result<PSO, PipelineError> {
         let rp = self

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -78,7 +78,7 @@ impl Renderer {
         })?;
 
         let builder = builder.extent([width, height]);
-        let (render_pass, mut targets, _attachments) = builder.build_with_images(&mut ctx)?;
+        let (render_pass, targets, _attachments) = builder.build_with_images(&mut ctx)?;
 
         assert!(render_pass.valid());
 


### PR DESCRIPTION
## Summary
- remove unused `ControlFlow` and `EventLoopExtRunReturn` imports
- drop unnecessary `mut` bindings to silence warnings
- verify build and tests succeed

## Testing
- `cargo build --example pbr_spheres`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6858bf410200832a8b330bafb910461e