### PR TITLE
Fix slice binding in tests

### DIFF
--- a/src/material/bindless_lighting.rs
+++ b/src/material/bindless_lighting.rs
@@ -221,7 +221,7 @@ mod tests {
             let ll = lights.lights.lock().unwrap();
             let handle = ll.entries[0];
             let buf = ll.get_ref(handle);
-            let mut slice = ctx.map_buffer_mut(buf.handle).unwrap();
+            let slice = ctx.map_buffer_mut(buf.handle).unwrap();
             let range = buf.offset as usize..buf.offset as usize + std::mem::size_of::<LightDesc>();
             for b in &mut slice[range] {
                 *b = 0;


### PR DESCRIPTION
## Summary
- fix borrow usage in bindless lighting tests by removing `mut` on `slice`

## Testing
- `cargo test` *(failed: build stalled during compiling shaderc-sys)*

------
https://chatgpt.com/codex/tasks/task_e_6858bf3bfbe8832a8f96c3301fc39d9e