### PR TITLE
Fix skeletal animation format

### DIFF
--- a/src/gltf/mod.rs
+++ b/src/gltf/mod.rs
@@ -163,7 +163,7 @@ fn load_node(
             let indices = reader.read_indices().map(|i| i.into_u32().collect());
             let joints = reader
                 .read_joints(0)
-                .map(|i| i.into_u16().collect::<Vec<_>>());
+                .map(|i| i.into_u16().map(|j| j.map(|v| v as u32)).collect::<Vec<_>>());
             let weights = reader
                 .read_weights(0)
                 .map(|i| i.into_f32().collect::<Vec<_>>());

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -18,6 +18,7 @@ pub(crate) fn reflect_format_to_shader_primitive(fmt: ReflectFormat) -> ShaderPr
     use ReflectFormat::*;
     match fmt {
         R32G32B32A32_SFLOAT => ShaderPrimitiveType::Vec4,
+        R32G32B32A32_SINT | R32G32B32A32_UINT => ShaderPrimitiveType::IVec4,
         R32G32B32_SFLOAT => ShaderPrimitiveType::Vec3,
         R32G32_SFLOAT => ShaderPrimitiveType::Vec2,
         other => panic!("Unsupported vertex input format: {:?}", other),

--- a/src/renderer/drawable.rs
+++ b/src/renderer/drawable.rs
@@ -31,7 +31,7 @@ pub struct SkeletalVertex {
     pub tangent: [f32; 4],
     pub uv: [f32; 2],
     pub color: [f32; 4],
-    pub joint_indices: [u16; 4],
+    pub joint_indices: [u32; 4],
     pub joint_weights: [f32; 4],
 }
 


### PR DESCRIPTION
## Summary
- support 32-bit integer vertex attributes in `PipelineBuilder`
- store joint indices as `u32` so vertex layout matches shader
- read joints as `u16` and cast to `u32` when loading glTF scenes

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68595ff0816c832aa3e8edf54e928838