### PR TITLE
Fix text PSO registration

### DIFF
--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -47,7 +47,7 @@ pub fn run(ctx: &mut Context) {
         .render_pass(renderer.render_pass(), 0)
         .build();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
-    renderer.register_pipeline_for_pass("main", pso, bgr);
+    renderer.register_pso(RenderStage::Text, pso, bgr);
 
     renderer.render_loop(|_r, _event| {});
 }

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -52,7 +52,7 @@ pub fn run() {
         .render_pass(renderer.render_pass(), 0)
         .build();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
-    renderer.register_pipeline_for_pass("main", pso, bgr);
+    renderer.register_pso(RenderStage::Text, pso, bgr);
 
     renderer.present_frame().unwrap();
     ctx.destroy();


### PR DESCRIPTION
## Summary
- replace deprecated pipeline registration in `examples/text2d/bin.rs` and `tests/text2d.rs`

## Testing
- `cargo test --quiet`
- `cargo build --example text2d --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685a1dab96cc832ab524d5098fe8387f