### PR TITLE
Add node_index to bones and support node-based animation update

### DIFF
--- a/src/gltf/mod.rs
+++ b/src/gltf/mod.rs
@@ -56,6 +56,7 @@ fn load_skin(skin: &gltf::Skin, buffers: &[gltf::buffer::Data]) -> Skeleton {
             name: joint.name().unwrap_or("").into(),
             parent: parents[i],
             inverse_bind: inverse[i],
+            node_index: joint.index(),
         });
     }
     Skeleton { bones }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -361,7 +361,7 @@ impl Renderer {
             if let Some(inst) = instances.get_mut(inst_idx) {
                 if let Some(player) = inst.player.as_mut() {
                     let local = player.advance(dt);
-                    inst.animator.update(&local);
+                    inst.animator.update_from_nodes(&local);
                     let _ = inst.update_gpu(ctx);
                 }
             }


### PR DESCRIPTION
## Summary
- extend `Bone` with `node_index`
- fill bone node indices when loading skins
- add `Animator::update_from_nodes`
- call `update_from_nodes` in `Renderer::play_animation`
- test `update_from_nodes` against GLTF sample

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685a1d9525f0832a8432bfbd57ca09aa