### PR TITLE
Add interactive text input example

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -253,6 +253,14 @@ impl Renderer {
         self.text_drawables.push(mesh);
     }
 
+    pub fn update_text_mesh(&mut self, idx: usize, mut mesh: StaticMesh) {
+        let ctx = self.get_ctx();
+        if let Some(slot) = self.text_drawables.get_mut(idx) {
+            mesh.upload(ctx).expect("Failed to upload text mesh to GPU");
+            *slot = mesh;
+        }
+    }
+
     /// Upload a skeletal mesh and its instances.
     pub fn register_skeletal_mesh(
         &mut self,


### PR DESCRIPTION
## Summary
- update renderer to allow replacing a text mesh
- modify `examples/text2d` to accept keyboard input and rebuild the text mesh

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685a22e33494832a97f117c0ea7944c7