### PR TITLE
Implement font registry

### DIFF
--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -35,7 +35,8 @@ pub fn run(ctx: &mut Context) {
     let mut renderer = Renderer::new(320, 240, "text", ctx).expect("renderer");
 
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    renderer.fonts_mut().register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(renderer.fonts(), "default");
     let mut input = String::new();
     let dim = text.upload_text_texture(ctx, renderer.resources(), "glyph_tex", &input, 32.0);
     let mesh = text.make_quad(dim, [-0.5, 0.5]);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -6,6 +6,7 @@ pub use time_stats::*;
 use crate::material::{BindlessLights, LightDesc, PSOBindGroupResources, PSO};
 use crate::render_pass::*;
 use crate::utils::{ResourceBinding, ResourceManager};
+use crate::text::FontRegistry;
 use dashi::utils::*;
 use dashi::*;
 use glam::Mat4;
@@ -36,6 +37,7 @@ pub struct Renderer {
     material_pipelines: HashMap<String, (PSO, [Option<PSOBindGroupResources>; 4])>,
     skeletal_pipeline: Option<(PSO, [Option<PSOBindGroupResources>; 4])>,
     resource_manager: ResourceManager,
+    fonts: FontRegistry,
     lights: BindlessLights,
     drawables: Vec<(StaticMesh, Option<DynamicBuffer>)>,
     text_drawables: Vec<StaticMesh>,
@@ -107,6 +109,7 @@ impl Renderer {
             text_drawables: Vec::new(),
             skeletal_meshes: Vec::new(),
             resource_manager,
+            fonts: FontRegistry::new(),
             lights,
             command_list,
             semaphores,
@@ -291,6 +294,14 @@ impl Renderer {
 
     pub fn resources(&mut self) -> &mut ResourceManager {
         &mut self.resource_manager
+    }
+
+    pub fn fonts(&self) -> &FontRegistry {
+        &self.fonts
+    }
+
+    pub fn fonts_mut(&mut self) -> &mut FontRegistry {
+        &mut self.fonts
     }
 
     /// Main render pass. The provided callback receives all window events as well

--- a/src/text/font_registry.rs
+++ b/src/text/font_registry.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+use rusttype::Font;
+
+/// Registry storing parsed fonts for reuse.
+pub struct FontRegistry {
+    fonts: HashMap<String, Font<'static>>,
+}
+
+impl FontRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self { fonts: HashMap::new() }
+    }
+
+    /// Parse and store font data under `name`.
+    pub fn register_font(&mut self, name: &str, bytes: &[u8]) {
+        if let Some(font) = Font::try_from_vec(bytes.to_vec()) {
+            self.fonts.insert(name.to_string(), font);
+        } else {
+            panic!("invalid font data for {}", name);
+        }
+    }
+
+    /// Retrieve a cloned [`Font`] by name.
+    pub fn get(&self, name: &str) -> Option<Font<'static>> {
+        self.fonts.get(name).cloned()
+    }
+}

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -3,19 +3,23 @@ use crate::utils::ResourceManager;
 
 mod static_text;
 mod dynamic_text;
+mod font_registry;
 
 pub use static_text::{StaticText, StaticTextCreateInfo};
 pub use dynamic_text::{DynamicText, DynamicTextCreateInfo};
+pub use font_registry::FontRegistry;
 use rusttype::{Font, Scale, point};
 use dashi::*;
 
-pub struct TextRenderer2D<'a> {
-    font: Font<'a>,
+pub struct TextRenderer2D {
+    font: Font<'static>,
 }
 
-impl<'a> TextRenderer2D<'a> {
-    pub fn new(font_data: &'a [u8]) -> Self {
-        let font = Font::try_from_bytes(font_data).expect("font");
+impl TextRenderer2D {
+    pub fn new(registry: &FontRegistry, name: &str) -> Self {
+        let font = registry
+            .get(name)
+            .expect("font not found in registry");
         Self { font }
     }
 

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -39,7 +39,8 @@ pub fn run() {
     let mut renderer = Renderer::new(320, 240, "text", &mut ctx).expect("renderer");
 
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    renderer.fonts_mut().register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(renderer.fonts(), "default");
     let dim = text.upload_text_texture(&mut ctx, renderer.resources(), "glyph_tex", "Hello", 32.0);
     let mesh = text.make_quad(dim, [-0.5, 0.5]);
     renderer.register_text_mesh(mesh);

--- a/tests/text_mesh.rs
+++ b/tests/text_mesh.rs
@@ -1,4 +1,4 @@
-use koji::text::{TextRenderer2D, StaticText, StaticTextCreateInfo, DynamicText, DynamicTextCreateInfo};
+use koji::text::{TextRenderer2D, StaticText, StaticTextCreateInfo, DynamicText, DynamicTextCreateInfo, FontRegistry};
 use koji::utils::{ResourceManager, ResourceBinding};
 use dashi::gpu;
 use serial_test::serial;
@@ -38,7 +38,9 @@ fn destroy_combined(ctx: &mut gpu::Context, res: &ResourceManager, key: &str) {
 #[serial]
 fn static_text_new_uploads_texture() {
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    let mut registry = FontRegistry::new();
+    registry.register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
     let info = StaticTextCreateInfo { text: "Hi", scale: 16.0, pos: [0.0, 0.0], key: "stex" };
@@ -56,7 +58,9 @@ fn static_text_new_uploads_texture() {
 #[ignore]
 fn dynamic_text_update_respects_max_chars() {
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    let mut registry = FontRegistry::new();
+    registry.register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
     let info = DynamicTextCreateInfo { max_chars: 4, text: "hey", scale: 16.0, pos: [0.0, 0.0], key: "dtex" };

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -1,4 +1,4 @@
-use koji::text::TextRenderer2D;
+use koji::text::{TextRenderer2D, FontRegistry};
 use koji::utils::{ResourceManager, ResourceBinding};
 use dashi::gpu;
 use rusttype::{Font, Scale, point};
@@ -56,7 +56,9 @@ fn expected_dims(text: &str, scale: f32, font_bytes: &[u8]) -> [u32; 2] {
 #[serial]
 fn new_loads_font_bytes() {
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    let mut registry = FontRegistry::new();
+    registry.register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
     let dim = text.upload_text_texture(&mut ctx, &mut res, "hello", "Hi", 20.0);
@@ -69,7 +71,9 @@ fn new_loads_font_bytes() {
 #[serial]
 fn upload_registers_texture_with_expected_dims() {
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    let mut registry = FontRegistry::new();
+    registry.register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
 
@@ -89,7 +93,9 @@ fn upload_registers_texture_with_expected_dims() {
 #[test]
 fn make_quad_generates_correct_vertices() {
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    let mut registry = FontRegistry::new();
+    registry.register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(&registry, "default");
     let dim = [16, 8];
     let pos = [1.0, 2.0];
     let mesh = text.make_quad(dim, pos);
@@ -115,7 +121,9 @@ fn make_quad_generates_correct_vertices() {
 #[should_panic]
 fn upload_empty_string_zero_texture() {
     let font_bytes = load_system_font();
-    let text = TextRenderer2D::new(&font_bytes);
+    let mut registry = FontRegistry::new();
+    registry.register_font("default", &font_bytes);
+    let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
     let dim = text.upload_text_texture(&mut ctx, &mut res, "empty", "", 16.0);


### PR DESCRIPTION
## Summary
- add `FontRegistry` for storing parsed fonts
- update `TextRenderer2D` to pull fonts from the registry
- expose font registry via `Renderer`
- update text examples and tests

## Testing
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685c0cdf7f38832abdc0cbf3b62eee0f