### PR TITLE
Fix text quad scaling

### DIFF
--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -37,7 +37,12 @@ pub fn run(ctx: &mut Context) {
     let font_bytes = load_system_font();
     let text = TextRenderer2D::new(&font_bytes);
     let mut input = String::new();
-    let dim = text.upload_text_texture(ctx, renderer.resources(), "glyph_tex", &input, 32.0);
+    let dim_px = text.upload_text_texture(ctx, renderer.resources(), "glyph_tex", &input, 32.0);
+    let win = renderer.window_size();
+    let dim = [
+        dim_px[0] as f32 / win[0] as f32 * 2.0,
+        dim_px[1] as f32 / win[1] as f32 * 2.0,
+    ];
     let mesh = text.make_quad(dim, [-0.5, 0.5]);
     renderer.register_text_mesh(mesh);
     let mesh_idx = 0usize;
@@ -81,7 +86,12 @@ pub fn run(ctx: &mut Context) {
         }
 
         if changed {
-            let dim = text.upload_text_texture(ctx, r.resources(), "glyph_tex", &input, 32.0);
+            let dim_px = text.upload_text_texture(ctx, r.resources(), "glyph_tex", &input, 32.0);
+            let win = r.window_size();
+            let dim = [
+                dim_px[0] as f32 / win[0] as f32 * 2.0,
+                dim_px[1] as f32 / win[1] as f32 * 2.0,
+            ];
             let mesh = text.make_quad(dim, [-0.5, 0.5]);
             r.update_text_mesh(mesh_idx, mesh);
         }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -170,6 +170,11 @@ impl Renderer {
         self.render_pass
     }
 
+    /// Current window size in pixels.
+    pub fn window_size(&self) -> [u32; 2] {
+        [self.width, self.height]
+    }
+
     pub fn set_clear_color(&mut self, color: [f32; 4]) {
         self.clear_color = color;
         for target in &mut self.targets {

--- a/src/text/dynamic_text.rs
+++ b/src/text/dynamic_text.rs
@@ -72,7 +72,8 @@ impl DynamicText {
         pos: [f32; 2],
     ) -> Result<(), GPUError> {
         assert!(text.len() <= self.max_chars);
-        let dim = renderer.upload_text_texture(ctx, res, &self.texture_key, text, scale);
+        let dim_px = renderer.upload_text_texture(ctx, res, &self.texture_key, text, scale);
+        let dim = [dim_px[0] as f32, dim_px[1] as f32];
         let mesh = renderer.make_quad(dim, pos);
         let vert_bytes: &[u8] = bytemuck::cast_slice(&mesh.vertices);
         assert!(vert_bytes.len() as u64 <= self.vertex_alloc.size);

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -78,9 +78,9 @@ impl<'a> TextRenderer2D<'a> {
     }
 
     /// Create a quad mesh covering the text dimensions.
-    pub fn make_quad(&self, dim: [u32; 2], pos: [f32; 2]) -> StaticMesh {
-        let w = dim[0] as f32;
-        let h = dim[1] as f32;
+    pub fn make_quad(&self, dim: [f32; 2], pos: [f32; 2]) -> StaticMesh {
+        let w = dim[0];
+        let h = dim[1];
         let verts = vec![
             Vertex { position: [pos[0], pos[1] - h, 0.0], normal: [0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[0.0,1.0], color:[1.0;4]},
             Vertex { position: [pos[0] + w, pos[1] - h, 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[1.0,1.0], color:[1.0;4]},

--- a/src/text/static_text.rs
+++ b/src/text/static_text.rs
@@ -34,14 +34,15 @@ impl StaticText {
         renderer: &TextRenderer2D,
         info: StaticTextCreateInfo<'_>,
     ) -> Result<Self, GPUError> {
-        let dim =
+        let dim_px =
             renderer.upload_text_texture(ctx, res, info.key, info.text, info.scale);
+        let dim = [dim_px[0] as f32, dim_px[1] as f32];
         let mut mesh = renderer.make_quad(dim, info.pos);
         mesh.upload(ctx)?;
         Ok(Self {
             mesh,
             texture_key: info.key.into(),
-            dim,
+            dim: dim_px,
         })
     }
 }

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -40,7 +40,8 @@ pub fn run() {
 
     let font_bytes = load_system_font();
     let text = TextRenderer2D::new(&font_bytes);
-    let dim = text.upload_text_texture(&mut ctx, renderer.resources(), "glyph_tex", "Hello", 32.0);
+    let dim_px = text.upload_text_texture(&mut ctx, renderer.resources(), "glyph_tex", "Hello", 32.0);
+    let dim = [dim_px[0] as f32, dim_px[1] as f32];
     let mesh = text.make_quad(dim, [-0.5, 0.5]);
     renderer.register_text_mesh(mesh);
 

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -90,7 +90,7 @@ fn upload_registers_texture_with_expected_dims() {
 fn make_quad_generates_correct_vertices() {
     let font_bytes = load_system_font();
     let text = TextRenderer2D::new(&font_bytes);
-    let dim = [16, 8];
+    let dim = [16.0, 8.0];
     let pos = [1.0, 2.0];
     let mesh = text.make_quad(dim, pos);
     let positions: Vec<[f32; 3]> = mesh.vertices.iter().map(|v| v.position).collect();


### PR DESCRIPTION
## Summary
- add `Renderer::window_size` to query display dimensions
- scale text quad to NDC in `examples/text2d`
- update text renderer to accept float dims
- adjust tests for new API

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c96aa5fe8832aa536a08f0f088077