### PR TITLE
Add TextRenderable trait and 3D text helper

### DIFF
--- a/src/text/dynamic_text.rs
+++ b/src/text/dynamic_text.rs
@@ -1,5 +1,5 @@
 use crate::renderer::Vertex;
-use crate::text::TextRenderer2D;
+use crate::text::{TextRenderer2D, TextRenderable};
 use crate::utils::{GpuAllocator, ResourceManager};
 use crate::utils::allocator::Allocation;
 use dashi::utils::Handle;
@@ -28,6 +28,20 @@ pub struct DynamicText {
     pub index_count: usize,
     pub max_chars: usize,
     pub texture_key: String,
+}
+
+impl TextRenderable for DynamicText {
+    fn vertex_buffer(&self) -> Handle<Buffer> {
+        self.vertex_alloc.buffer
+    }
+
+    fn index_buffer(&self) -> Option<Handle<Buffer>> {
+        Some(self.index_alloc.buffer)
+    }
+
+    fn index_count(&self) -> usize {
+        self.index_count
+    }
 }
 
 impl DynamicText {

--- a/src/text/static_text.rs
+++ b/src/text/static_text.rs
@@ -1,7 +1,8 @@
 use crate::renderer::StaticMesh;
-use crate::text::TextRenderer2D;
+use crate::text::{TextRenderer2D, TextRenderable};
 use crate::utils::ResourceManager;
 use dashi::*;
+use dashi::utils::Handle;
 
 /// Parameters for constructing [`StaticText`].
 pub struct StaticTextCreateInfo<'a> {
@@ -23,6 +24,20 @@ pub struct StaticText {
     pub texture_key: String,
     /// Dimensions of the generated texture
     pub dim: [u32; 2],
+}
+
+impl TextRenderable for StaticText {
+    fn vertex_buffer(&self) -> Handle<Buffer> {
+        self.mesh.vertex_buffer.expect("text vertex buffer")
+    }
+
+    fn index_buffer(&self) -> Option<Handle<Buffer>> {
+        self.mesh.index_buffer
+    }
+
+    fn index_count(&self) -> usize {
+        self.mesh.index_count
+    }
 }
 
 impl StaticText {


### PR DESCRIPTION
## Summary
- add `TextRenderable` trait for unified text meshes
- extend `TextRenderer2D` with 3D quad generation and `TextSpace`
- implement the trait for `StaticText` and `DynamicText`
- store text drawables as trait objects and update drawing code
- register/update text meshes using the trait

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685ca92890bc832a94a64d8d08b87e6b