### PR TITLE
Propagate GPU errors in text texture upload

### DIFF
--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -40,7 +40,9 @@ pub fn run(ctx: &mut Context) {
     renderer.fonts_mut().register_font("default", &font_bytes);
     let text = TextRenderer2D::new(renderer.fonts(), "default");
 
-    let dim = text.upload_text_texture(ctx, renderer.resources(), "text3d_tex", "3D Text", 32.0);
+    let dim = text
+        .upload_text_texture(ctx, renderer.resources(), "text3d_tex", "3D Text", 32.0)
+        .unwrap();
     let proj = Mat4::perspective_rh_gl(45_f32.to_radians(), 320.0 / 240.0, 0.1, 10.0);
     let view = Mat4::look_at_rh(Vec3::new(0.0, 0.0, 2.0), Vec3::ZERO, Vec3::Y);
     let mat = proj * view * Mat4::IDENTITY;

--- a/src/text/dynamic_text.rs
+++ b/src/text/dynamic_text.rs
@@ -86,7 +86,7 @@ impl DynamicText {
         pos: [f32; 2],
     ) -> Result<(), GPUError> {
         assert!(text.len() <= self.max_chars);
-        let dim = renderer.upload_text_texture(ctx, res, &self.texture_key, text, scale);
+        let dim = renderer.upload_text_texture(ctx, res, &self.texture_key, text, scale)?;
         let mesh = renderer.make_quad(dim, pos);
         let vert_bytes: &[u8] = bytemuck::cast_slice(&mesh.vertices);
         assert!(vert_bytes.len() as u64 <= self.vertex_alloc.size);

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -53,7 +53,7 @@ impl TextRenderer2D {
         key: &str,
         text: &str,
         scale: f32,
-    ) -> [u32; 2] {
+    ) -> Result<[u32; 2], GPUError> {
         let scale = Scale::uniform(scale);
         let v_metrics = self.font.v_metrics(scale);
         let glyphs: Vec<_> = self
@@ -85,22 +85,18 @@ impl TextRenderer2D {
             rgba[i * 4 + 2] = 255;
             rgba[i * 4 + 3] = *a;
         }
-        let img = ctx
-            .make_image(&ImageInfo {
+        let img = ctx.make_image(&ImageInfo {
                 debug_name: "text",
                 dim: [width as u32, height as u32, 1],
                 format: Format::RGBA8,
                 mip_levels: 1,
                 layers: 1,
                 initial_data: Some(&rgba),
-            })
-            .unwrap();
-        let view = ctx
-            .make_image_view(&ImageViewInfo { img, ..Default::default() })
-            .unwrap();
-        let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();
+            })?;
+        let view = ctx.make_image_view(&ImageViewInfo { img, ..Default::default() })?;
+        let sampler = ctx.make_sampler(&SamplerInfo::default())?;
         res.register_combined(key, img, view, [width as u32, height as u32], sampler);
-        [width as u32, height as u32]
+        Ok([width as u32, height as u32])
     }
 
     /// Create a quad mesh covering the text dimensions.

--- a/src/text/static_text.rs
+++ b/src/text/static_text.rs
@@ -50,7 +50,7 @@ impl StaticText {
         info: StaticTextCreateInfo<'_>,
     ) -> Result<Self, GPUError> {
         let dim =
-            renderer.upload_text_texture(ctx, res, info.key, info.text, info.scale);
+            renderer.upload_text_texture(ctx, res, info.key, info.text, info.scale)?;
         let mut mesh = renderer.make_quad(dim, info.pos);
         mesh.upload(ctx)?;
         Ok(Self {

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -66,7 +66,9 @@ fn new_loads_font_bytes() {
     let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let dim = text.upload_text_texture(&mut ctx, &mut res, "hello", "Hi", 20.0);
+    let dim = text
+        .upload_text_texture(&mut ctx, &mut res, "hello", "Hi", 20.0)
+        .unwrap();
     assert_eq!(dim, expected_dims("Hi", 20.0, &font_bytes));
     destroy_combined(&mut ctx, &res, "hello");
     ctx.destroy();
@@ -82,7 +84,9 @@ fn upload_registers_texture_with_expected_dims() {
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
 
-    let dim = text.upload_text_texture(&mut ctx, &mut res, "greeting", "Hello", 32.0);
+    let dim = text
+        .upload_text_texture(&mut ctx, &mut res, "greeting", "Hello", 32.0)
+        .unwrap();
     let expected = expected_dims("Hello", 32.0, &font_bytes);
     assert_eq!(dim, expected);
     match res.get("greeting") {
@@ -131,7 +135,9 @@ fn upload_empty_string_zero_texture() {
     let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let dim = text.upload_text_texture(&mut ctx, &mut res, "empty", "", 16.0);
+    let dim = text
+        .upload_text_texture(&mut ctx, &mut res, "empty", "", 16.0)
+        .unwrap();
     assert_eq!(dim[0], 0);
     match res.get("empty") {
         Some(ResourceBinding::CombinedImageSampler { texture, .. }) => {


### PR DESCRIPTION
## Summary
- return a `Result` from `TextRenderer2D::upload_text_texture`
- propagate this `Result` in `StaticText` and `DynamicText`
- update tests and examples for the new signatures

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68605f6346fc832a9f9f90d9037fbeee