### PR TITLE
Fix glyph texture keys in text examples

### DIFF
--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -64,10 +64,10 @@ pub fn run(ctx: &mut Context) {
         renderer.resources(),
         &text,
         StaticTextCreateInfo {
-            text: "Static text", 
-            scale: 32.0, 
+            text: "Static text",
+            scale: 32.0,
             pos: [-0.9, 0.9],
-            key: "static_tex",
+            key: "glyph_tex",
         },
     ).unwrap();
     renderer.register_text_mesh(static_text);
@@ -83,7 +83,7 @@ pub fn run(ctx: &mut Context) {
                 text: "",
                 scale: 32.0,
                 pos: [-0.5, 0.5],
-                key: "dyn_tex",
+                key: "glyph_tex",
             },
         )
         .expect("failed to create DynamicText"),

--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -41,7 +41,7 @@ pub fn run(ctx: &mut Context) {
     let text = TextRenderer2D::new(renderer.fonts(), "default");
 
     let dim = text
-        .upload_text_texture(ctx, renderer.resources(), "text3d_tex", "3D Text", 32.0)
+        .upload_text_texture(ctx, renderer.resources(), "glyph_tex", "3D Text", 32.0)
         .unwrap();
     let proj = Mat4::perspective_rh_gl(45_f32.to_radians(), 320.0 / 240.0, 0.1, 10.0);
     let view = Mat4::look_at_rh(Vec3::new(0.0, 0.0, 2.0), Vec3::ZERO, Vec3::Y);


### PR DESCRIPTION
## Summary
- use uniform `glyph_tex` key for text2d and text3d examples

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68675dc5d3f4832a8d83eab32697ec5d