### PR TITLE
Support NDC for StaticText

### DIFF
--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -68,6 +68,7 @@ pub fn run(ctx: &mut Context) {
             scale: 32.0,
             pos: [-0.9, 0.9],
             key: "glyph_tex",
+            screen_size: [320.0, 240.0],
         },
     ).unwrap();
     renderer.register_text_mesh(static_text);

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -140,6 +140,27 @@ impl TextRenderer2D {
         }
     }
 
+    /// Create a quad mesh covering the text dimensions in NDC space.
+    pub fn make_quad_ndc(&self, dim: [u32; 2], pos: [f32; 2], screen_size: [f32; 2]) -> StaticMesh {
+        let w = 2.0 * dim[0] as f32 / screen_size[0];
+        let h = 2.0 * dim[1] as f32 / screen_size[1];
+        let verts = vec![
+            Vertex { position: [pos[0], pos[1] - h, 0.0], normal: [0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[0.0,1.0], color:[1.0;4]},
+            Vertex { position: [pos[0] + w, pos[1] - h, 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[1.0,1.0], color:[1.0;4]},
+            Vertex { position: [pos[0] + w, pos[1], 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[1.0,0.0], color:[1.0;4]},
+            Vertex { position: [pos[0], pos[1], 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[0.0,0.0], color:[1.0;4]},
+        ];
+        let indices = vec![0u32,1,2,2,3,0];
+        StaticMesh {
+            material_id: "text".into(),
+            vertices: verts,
+            indices: Some(indices),
+            vertex_buffer: None,
+            index_buffer: None,
+            index_count: 0,
+        }
+    }
+
     /// Create a quad mesh transformed by `mat`.
     pub fn make_quad_3d(&self, dim: [u32; 2], mat: Mat4) -> StaticMesh {
         let w = dim[0] as f32;

--- a/src/text/static_text.rs
+++ b/src/text/static_text.rs
@@ -14,6 +14,8 @@ pub struct StaticTextCreateInfo<'a> {
     pub pos: [f32; 2],
     /// Resource key for the uploaded texture
     pub key: &'a str,
+    /// Screen dimensions for converting glyph metrics to NDC
+    pub screen_size: [f32; 2],
 }
 
 /// Immutable text mesh with pre-generated geometry and glyph texture.
@@ -51,7 +53,7 @@ impl StaticText {
     ) -> Result<Self, GPUError> {
         let dim =
             renderer.upload_text_texture(ctx, res, info.key, info.text, info.scale)?;
-        let mut mesh = renderer.make_quad(dim, info.pos);
+        let mut mesh = renderer.make_quad_ndc(dim, info.pos, info.screen_size);
         mesh.upload(ctx)?;
         Ok(Self {
             mesh,

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -34,6 +34,24 @@ fn make_frag() -> Vec<u32> {
     include_spirv!("assets/shaders/text.frag", frag).to_vec()
 }
 
+fn expected_dims(text: &str, scale: f32, font_bytes: &[u8]) -> [u32; 2] {
+    use rusttype::{Font, Scale, point};
+    let font = Font::try_from_bytes(font_bytes).expect("font");
+    let scale = Scale::uniform(scale);
+    let v_metrics = font.v_metrics(scale);
+    let glyphs: Vec<_> = font
+        .layout(text, scale, point(0.0, v_metrics.ascent))
+        .collect();
+    let width = glyphs
+        .iter()
+        .rev()
+        .filter_map(|g| g.pixel_bounding_box().map(|bb| bb.max.x as i32))
+        .next()
+        .unwrap_or(0);
+    let height = (v_metrics.ascent - v_metrics.descent).ceil() as u32;
+    [width as u32, height]
+}
+
 #[cfg(feature = "gpu_tests")]
 pub fn run() {
     let device = DeviceSelector::new().unwrap().select(DeviceFilter::default().add_required_type(DeviceType::Dedicated)).unwrap_or_default();
@@ -43,8 +61,24 @@ pub fn run() {
     let font_bytes = load_system_font();
     renderer.fonts_mut().register_font("default", &font_bytes);
     let text = TextRenderer2D::new(renderer.fonts(), "default");
-    let info = StaticTextCreateInfo { text: "Hello", scale: 32.0, pos: [-0.5, 0.5], key: "glyph_tex" };
+    let info = StaticTextCreateInfo {
+        text: "Hello",
+        scale: 32.0,
+        pos: [-0.5, 0.5],
+        key: "glyph_tex",
+        screen_size: [320.0, 240.0],
+    };
     let mesh = StaticText::new(&mut ctx, renderer.resources(), &text, info).unwrap();
+    let expected_dim = expected_dims("Hello", 32.0, &font_bytes);
+    let w = 2.0 * expected_dim[0] as f32 / 320.0;
+    let h = 2.0 * expected_dim[1] as f32 / 240.0;
+    let positions: Vec<[f32; 3]> = mesh.mesh.vertices.iter().map(|v| v.position).collect();
+    assert_eq!(positions, vec![
+        [-0.5, 0.5 - h, 0.0],
+        [-0.5 + w, 0.5 - h, 0.0],
+        [-0.5 + w, 0.5, 0.0],
+        [-0.5, 0.5, 0.0],
+    ]);
     renderer.register_text_mesh(mesh);
 
     let vert_spv = make_vert();

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -157,8 +157,24 @@ fn static_text_preserves_gpu_buffers() {
     let text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let info = StaticTextCreateInfo { text: "Hi", scale: 16.0, pos: [0.0, 0.0], key: "stex" };
+    let info = StaticTextCreateInfo {
+        text: "Hi",
+        scale: 16.0,
+        pos: [0.0, 0.0],
+        key: "stex",
+        screen_size: [320.0, 240.0],
+    };
     let mut st = StaticText::new(&mut ctx, &mut res, &text, info).unwrap();
+    let expected_dim = expected_dims("Hi", 16.0, &font_bytes);
+    let w = 2.0 * expected_dim[0] as f32 / 320.0;
+    let h = 2.0 * expected_dim[1] as f32 / 240.0;
+    let positions: Vec<[f32; 3]> = st.mesh.vertices.iter().map(|v| v.position).collect();
+    assert_eq!(positions, vec![
+        [0.0, 0.0 - h, 0.0],
+        [0.0 + w, 0.0 - h, 0.0],
+        [0.0 + w, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ]);
     let vb = st.mesh.vertex_buffer.expect("vb");
     let ib = st.mesh.index_buffer.expect("ib");
 


### PR DESCRIPTION
## Summary
- expand `StaticTextCreateInfo` with `screen_size`
- add `TextRenderer2D::make_quad_ndc` for converting to NDC
- create quads in NDC when constructing `StaticText`
- pass screen size in the text2d example
- update tests to supply screen size and check vertex positions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68687c694b50832a89ec0850a075236c