### PR TITLE
Restrict StaticText GPU handles

### DIFF
--- a/src/text/static_text.rs
+++ b/src/text/static_text.rs
@@ -112,14 +112,14 @@ impl TextAtlas {
 /// Immutable text mesh with pre-generated geometry and glyph texture.
 pub struct StaticText {
     /// Quad mesh uploaded to the GPU
-    pub mesh: StaticMesh,
+    mesh: StaticMesh,
     atlas: TextAtlas,
     /// Resource manager key for the glyph texture
     pub texture_key: String,
     /// Index into the bindless texture array
     pub tex_index: u32,
     /// Dimensions of the generated texture
-    pub dim: [u32; 2],
+    dim: [u32; 2],
 }
 
 impl TextRenderable for StaticText {
@@ -184,5 +184,25 @@ impl StaticText {
             tex_index,
             dim,
         })
+    }
+
+    /// GPU handle for the vertex buffer.
+    pub fn vertex_buffer(&self) -> Handle<Buffer> {
+        self.mesh.vertex_buffer.expect("text vertex buffer")
+    }
+
+    /// GPU handle for the index buffer.
+    pub fn index_buffer(&self) -> Option<Handle<Buffer>> {
+        self.mesh.index_buffer
+    }
+
+    /// Number of indices for drawing this text.
+    pub fn index_count(&self) -> usize {
+        self.mesh.index_count
+    }
+
+    /// Dimensions of the uploaded glyph texture.
+    pub fn dim(&self) -> [u32; 2] {
+        self.dim
     }
 }

--- a/tests/text_mesh.rs
+++ b/tests/text_mesh.rs
@@ -53,11 +53,11 @@ fn static_text_new_uploads_texture() {
         key: "stex",
     };
     let s = StaticText::new(&mut ctx, &mut res, &mut text, info).unwrap();
-    assert_eq!(s.dim[0] > 0, true);
+    assert_eq!(s.dim()[0] > 0, true);
     assert!(res.get("stex").is_some());
     destroy_combined(&mut ctx, &res, "stex");
-    if let Some(vb) = s.mesh.vertex_buffer { ctx.destroy_buffer(vb); }
-    if let Some(ib) = s.mesh.index_buffer { ctx.destroy_buffer(ib); }
+    if let Some(ib) = s.index_buffer() { ctx.destroy_buffer(ib); }
+    ctx.destroy_buffer(s.vertex_buffer());
     ctx.destroy();
 }
 

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -159,16 +159,14 @@ fn static_text_preserves_gpu_buffers() {
     let mut res = ResourceManager::default();
     let info = StaticTextCreateInfo { text: "Hi", scale: 16.0, pos: [0.0, 0.0], key: "stex" };
     let mut st = StaticText::new(&mut ctx, &mut res, &mut text, info).unwrap();
-    let vb = st.mesh.vertex_buffer.expect("vb");
-    let ib = st.mesh.index_buffer.expect("ib");
+    let vb = st.vertex_buffer();
+    let ib = st.index_buffer().expect("ib");
 
-    // mutate fields after creation
-    st.dim = [0, 0];
-    st.mesh.vertices[0].position[0] += 1.0;
+    // modify a non-buffer field
     st.texture_key = "stex".into();
 
-    assert_eq!(st.mesh.vertex_buffer.unwrap(), vb);
-    assert_eq!(st.mesh.index_buffer.unwrap(), ib);
+    assert_eq!(st.vertex_buffer(), vb);
+    assert_eq!(st.index_buffer().unwrap(), ib);
 
     destroy_combined(&mut ctx, &res, "stex");
     ctx.destroy_buffer(vb);


### PR DESCRIPTION
## Summary
- hide mesh and dim fields of `StaticText`
- expose read-only helpers to query GPU buffers and dimensions
- update tests to use new API and confirm buffers remain unchanged

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68701a2c1a94832a927956ef26650b09