### PR TITLE
Add vertex color support for text

### DIFF
--- a/assets/shaders/text.frag
+++ b/assets/shaders/text.frag
@@ -1,9 +1,10 @@
 #version 450
 #extension GL_EXT_nonuniform_qualifier : enable
 layout(location = 0) in vec2 vUV;
-layout(location = 1) flat in uint vTexIndex;
+layout(location = 1) in vec4 vColor;
+layout(location = 2) flat in uint vTexIndex;
 layout(set = 0, binding = 0) uniform sampler2D glyph_textures[];
 layout(location = 0) out vec4 outColor;
 void main() {
-    outColor = texture(glyph_textures[vTexIndex], vUV);
+    outColor = texture(glyph_textures[vTexIndex], vUV) * vColor;
 }

--- a/assets/shaders/text.vert
+++ b/assets/shaders/text.vert
@@ -5,9 +5,11 @@ layout(location = 2) in vec4 inTangent;
 layout(location = 3) in vec2 inUV;
 layout(location = 4) in vec4 inColor;
 layout(location = 0) out vec2 vUV;
-layout(location = 1) flat out uint vTexIndex;
+layout(location = 1) out vec4 vColor;
+layout(location = 2) flat out uint vTexIndex;
 void main() {
     gl_Position = vec4(inPos, 1.0);
     vUV = inUV;
-    vTexIndex = uint(inColor.x);
+    vColor = inColor;
+    vTexIndex = uint(inTangent.w);
 }

--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -68,6 +68,7 @@ pub fn run(ctx: &mut Context) {
             scale: 32.0,
             pos: [-0.9, 0.9],
             key: "glyph_tex",
+            color: [1.0; 4],
         },
     ).unwrap();
     renderer.register_text_mesh(static_text);
@@ -85,6 +86,7 @@ pub fn run(ctx: &mut Context) {
                 pos: [-0.5, 0.5],
                 key: "glyph_tex",
                 screen_size: [320.0, 240.0],
+                color: [1.0; 4],
             },
         )
         .expect("failed to create DynamicText"),

--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -46,7 +46,7 @@ pub fn run(ctx: &mut Context) {
     let proj = Mat4::perspective_rh_gl(45_f32.to_radians(), 320.0 / 240.0, 0.1, 10.0);
     let view = Mat4::look_at_rh(Vec3::new(0.0, 0.0, 2.0), Vec3::ZERO, Vec3::Y);
     let mat = proj * view * Mat4::IDENTITY;
-    let mesh = text.make_quad_3d(dim, mat, _idx);
+    let mesh = text.make_quad_3d(dim, mat, _idx, [1.0; 4]);
     renderer.register_text_mesh(mesh);
     text.register_textures(renderer.resources());
     let mesh_idx = 0usize;
@@ -69,7 +69,7 @@ pub fn run(ctx: &mut Context) {
             let mat = proj
                 * view
                 * Mat4::from_rotation_y(angle);
-            let mesh2 = text.make_quad_3d(dim, mat, _idx);
+            let mesh2 = text.make_quad_3d(dim, mat, _idx, [1.0; 4]);
             r.update_text_mesh(mesh_idx, mesh2);
         }
     });

--- a/src/text/dynamic_text.rs
+++ b/src/text/dynamic_text.rs
@@ -20,6 +20,8 @@ pub struct DynamicTextCreateInfo<'a> {
     pub key: &'a str,
     /// Screen dimensions for converting glyph metrics to NDC
     pub screen_size: [f32; 2],
+    /// Color of the rendered text
+    pub color: [f32; 4],
 }
 
 struct GlyphInfo {
@@ -123,6 +125,7 @@ pub struct DynamicText {
     pub max_chars: usize,
     pub texture_key: String,
     tex_index: u32,
+    color: [f32; 4],
     scale: f32,
     screen_size: [f32; 2],
 }
@@ -179,6 +182,7 @@ impl DynamicText {
             max_chars: info.max_chars,
             texture_key: info.key.into(),
             tex_index: idx,
+            color: info.color,
             scale: info.scale,
             screen_size: info.screen_size,
         };
@@ -215,11 +219,12 @@ impl DynamicText {
                 let x1 = cursor + adv;
                 let y0 = pos[1] - 2.0 * self.atlas.line_height / sy;
                 let y1 = pos[1];
-                let c = [self.tex_index as f32, 0.0, 0.0, 1.0];
-                verts.push(Vertex { position: [x0, y0, 0.0], normal: [0.0; 3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_min[0], g.uv_max[1]], color: c });
-                verts.push(Vertex { position: [x1, y0, 0.0], normal: [0.0; 3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_max[0], g.uv_max[1]], color: c });
-                verts.push(Vertex { position: [x1, y1, 0.0], normal: [0.0; 3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_max[0], g.uv_min[1]], color: c });
-                verts.push(Vertex { position: [x0, y1, 0.0], normal: [0.0; 3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_min[0], g.uv_min[1]], color: c });
+                let c = self.color;
+                let t = [1.0, 0.0, 0.0, self.tex_index as f32];
+                verts.push(Vertex { position: [x0, y0, 0.0], normal: [0.0; 3], tangent: t, uv: [g.uv_min[0], g.uv_max[1]], color: c });
+                verts.push(Vertex { position: [x1, y0, 0.0], normal: [0.0; 3], tangent: t, uv: [g.uv_max[0], g.uv_max[1]], color: c });
+                verts.push(Vertex { position: [x1, y1, 0.0], normal: [0.0; 3], tangent: t, uv: [g.uv_max[0], g.uv_min[1]], color: c });
+                verts.push(Vertex { position: [x0, y1, 0.0], normal: [0.0; 3], tangent: t, uv: [g.uv_min[0], g.uv_min[1]], color: c });
                 inds.extend_from_slice(&[base, base + 1, base + 2, base + 2, base + 3, base]);
                 cursor += adv;
             }

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -163,14 +163,14 @@ impl TextRenderer2D {
     }
 
     /// Create a quad mesh covering the text dimensions.
-    pub fn make_quad(&self, dim: [u32; 2], pos: [f32; 2], tex_index: u32) -> StaticMesh {
+    pub fn make_quad(&self, dim: [u32; 2], pos: [f32; 2], tex_index: u32, color: [f32; 4]) -> StaticMesh {
         let w = dim[0] as f32;
         let h = dim[1] as f32;
         let verts = vec![
-            Vertex { position: [pos[0], pos[1] - h, 0.0], normal: [0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[0.0,1.0], color:[tex_index as f32,0.0,0.0,1.0]},
-            Vertex { position: [pos[0] + w, pos[1] - h, 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[1.0,1.0], color:[tex_index as f32,0.0,0.0,1.0]},
-            Vertex { position: [pos[0] + w, pos[1], 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[1.0,0.0], color:[tex_index as f32,0.0,0.0,1.0]},
-            Vertex { position: [pos[0], pos[1], 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,1.0], uv:[0.0,0.0], color:[tex_index as f32,0.0,0.0,1.0]},
+            Vertex { position: [pos[0], pos[1] - h, 0.0], normal: [0.0;3], tangent:[1.0,0.0,0.0,tex_index as f32], uv:[0.0,1.0], color },
+            Vertex { position: [pos[0] + w, pos[1] - h, 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,tex_index as f32], uv:[1.0,1.0], color },
+            Vertex { position: [pos[0] + w, pos[1], 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,tex_index as f32], uv:[1.0,0.0], color },
+            Vertex { position: [pos[0], pos[1], 0.0], normal:[0.0;3], tangent:[1.0,0.0,0.0,tex_index as f32], uv:[0.0,0.0], color },
         ];
         let indices = vec![0u32,1,2,2,3,0];
         StaticMesh {
@@ -185,7 +185,7 @@ impl TextRenderer2D {
 
 
     /// Create a quad mesh transformed by `mat`.
-    pub fn make_quad_3d(&self, dim: [u32; 2], mat: Mat4, tex_index: u32) -> StaticMesh {
+    pub fn make_quad_3d(&self, dim: [u32; 2], mat: Mat4, tex_index: u32, color: [f32; 4]) -> StaticMesh {
         let w = dim[0] as f32;
         let h = dim[1] as f32;
         let base = [
@@ -208,9 +208,9 @@ impl TextRenderer2D {
                 Vertex {
                     position: pos.into(),
                     normal: [0.0; 3],
-                    tangent: [1.0, 0.0, 0.0, 1.0],
+                    tangent: [1.0, 0.0, 0.0, tex_index as f32],
                     uv,
-                    color: [tex_index as f32, 0.0, 0.0, 1.0],
+                    color,
                 }
             })
             .collect();
@@ -226,10 +226,10 @@ impl TextRenderer2D {
     }
 
     /// Create a text mesh either in 2D or 3D space.
-    pub fn make_text_mesh(&self, dim: [u32; 2], space: TextSpace, tex_index: u32) -> StaticMesh {
+    pub fn make_text_mesh(&self, dim: [u32; 2], space: TextSpace, tex_index: u32, color: [f32; 4]) -> StaticMesh {
         match space {
-            TextSpace::Dim2(p) => self.make_quad(dim, p, tex_index),
-            TextSpace::Dim3(m) => self.make_quad_3d(dim, m, tex_index),
+            TextSpace::Dim2(p) => self.make_quad(dim, p, tex_index, color),
+            TextSpace::Dim3(m) => self.make_quad_3d(dim, m, tex_index, color),
         }
     }
 }

--- a/src/text/static_text.rs
+++ b/src/text/static_text.rs
@@ -16,6 +16,8 @@ pub struct StaticTextCreateInfo<'a> {
     pub pos: [f32; 2],
     /// Resource key for the uploaded texture
     pub key: &'a str,
+    /// Color of the rendered text
+    pub color: [f32; 4],
 }
 
 struct GlyphInfo {
@@ -158,11 +160,12 @@ impl StaticText {
                 let x1 = cursor + adv;
                 let y0 = info.pos[1] - atlas.line_height;
                 let y1 = info.pos[1];
-                let c = [tex_index as f32, 0.0, 0.0, 1.0];
-                verts.push(Vertex { position: [x0, y0, 0.0], normal: [0.0;3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_min[0], g.uv_max[1]], color: c });
-                verts.push(Vertex { position: [x1, y0, 0.0], normal: [0.0;3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_max[0], g.uv_max[1]], color: c });
-                verts.push(Vertex { position: [x1, y1, 0.0], normal: [0.0;3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_max[0], g.uv_min[1]], color: c });
-                verts.push(Vertex { position: [x0, y1, 0.0], normal: [0.0;3], tangent: [1.0,0.0,0.0,1.0], uv: [g.uv_min[0], g.uv_min[1]], color: c });
+                let c = info.color;
+                let t = [1.0, 0.0, 0.0, tex_index as f32];
+                verts.push(Vertex { position: [x0, y0, 0.0], normal: [0.0;3], tangent: t, uv: [g.uv_min[0], g.uv_max[1]], color: c });
+                verts.push(Vertex { position: [x1, y0, 0.0], normal: [0.0;3], tangent: t, uv: [g.uv_max[0], g.uv_max[1]], color: c });
+                verts.push(Vertex { position: [x1, y1, 0.0], normal: [0.0;3], tangent: t, uv: [g.uv_max[0], g.uv_min[1]], color: c });
+                verts.push(Vertex { position: [x0, y1, 0.0], normal: [0.0;3], tangent: t, uv: [g.uv_min[0], g.uv_min[1]], color: c });
                 inds.extend_from_slice(&[base, base + 1, base + 2, base + 2, base + 3, base]);
                 cursor += adv;
             }

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -61,7 +61,7 @@ pub fn run() {
     let font_bytes = load_system_font();
     renderer.fonts_mut().register_font("default", &font_bytes);
     let mut text = TextRenderer2D::new(renderer.fonts(), "default");
-    let info = StaticTextCreateInfo { text: "Hello", scale: 32.0, pos: [-0.5, 0.5], key: "glyph_tex" };
+    let info = StaticTextCreateInfo { text: "Hello", scale: 32.0, pos: [-0.5, 0.5], key: "glyph_tex", color: [1.0; 4] };
     let mesh = StaticText::new(&mut ctx, renderer.resources(), &mut text, info).unwrap();
     renderer.register_text_mesh(mesh);
     text.register_textures(renderer.resources());

--- a/tests/text_mesh.rs
+++ b/tests/text_mesh.rs
@@ -51,6 +51,7 @@ fn static_text_new_uploads_texture() {
         scale: 16.0,
         pos: [0.0, 0.0],
         key: "stex",
+        color: [1.0; 4],
     };
     let s = StaticText::new(&mut ctx, &mut res, &mut text, info).unwrap();
     assert_eq!(s.dim()[0] > 0, true);
@@ -71,7 +72,7 @@ fn dynamic_text_update_respects_max_chars() {
     let mut text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let info = DynamicTextCreateInfo { max_chars: 4, text: "hey", scale: 16.0, pos: [0.0, 0.0], key: "dtex", screen_size: [320.0, 240.0] };
+    let info = DynamicTextCreateInfo { max_chars: 4, text: "hey", scale: 16.0, pos: [0.0, 0.0], key: "dtex", screen_size: [320.0, 240.0], color: [1.0; 4] };
     let mut d = DynamicText::new(&mut ctx, &mut text, &mut res, info).unwrap();
     assert_eq!(d.vertex_count, 4);
     assert!(res.get("dtex").is_some());

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -107,7 +107,7 @@ fn make_quad_generates_correct_vertices() {
     let mut text = TextRenderer2D::new(&registry, "default");
     let dim = [16, 8];
     let pos = [1.0, 2.0];
-    let mesh = text.make_quad(dim, pos, 0);
+    let mesh = text.make_quad(dim, pos, 0, [1.0; 4]);
     let positions: Vec<[f32; 3]> = mesh.vertices.iter().map(|v| v.position).collect();
     assert_eq!(positions, vec![
         [1.0, 2.0 - 8.0, 0.0],
@@ -157,7 +157,7 @@ fn static_text_preserves_gpu_buffers() {
     let mut text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let info = StaticTextCreateInfo { text: "Hi", scale: 16.0, pos: [0.0, 0.0], key: "stex" };
+    let info = StaticTextCreateInfo { text: "Hi", scale: 16.0, pos: [0.0, 0.0], key: "stex", color: [1.0; 4] };
     let mut st = StaticText::new(&mut ctx, &mut res, &mut text, info).unwrap();
     let vb = st.vertex_buffer();
     let ib = st.index_buffer().expect("ib");
@@ -184,7 +184,7 @@ fn dynamic_text_updates_vertices_and_respects_capacity() {
     let mut text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let info = DynamicTextCreateInfo { max_chars: 8, text: "hi", scale: 16.0, pos: [0.0, 0.0], key: "dtex", screen_size: [320.0, 240.0] };
+    let info = DynamicTextCreateInfo { max_chars: 8, text: "hi", scale: 16.0, pos: [0.0, 0.0], key: "dtex", screen_size: [320.0, 240.0], color: [1.0; 4] };
     let mut dt = DynamicText::new(&mut ctx, &mut text, &mut res, info).unwrap();
     let vb = dt.vertex_buffer();
     assert_eq!(dt.vertex_count, 4);
@@ -215,7 +215,7 @@ fn dynamic_text_update_empty_string_resets_counts() {
     let mut text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let info = DynamicTextCreateInfo { max_chars: 8, text: "hello", scale: 16.0, pos: [0.0, 0.0], key: "emt", screen_size: [320.0, 240.0] };
+    let info = DynamicTextCreateInfo { max_chars: 8, text: "hello", scale: 16.0, pos: [0.0, 0.0], key: "emt", screen_size: [320.0, 240.0], color: [1.0; 4] };
     let mut dt = DynamicText::new(&mut ctx, &mut text, &mut res, info).unwrap();
     dt.update_text(&mut ctx, &mut res, &mut text, "", 16.0, [0.0, 0.0]).unwrap();
     assert_eq!(dt.vertex_count, 0);
@@ -235,7 +235,7 @@ fn dynamic_text_update_over_capacity_panics() {
     let mut text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let info = DynamicTextCreateInfo { max_chars: 2, text: "hi", scale: 16.0, pos: [0.0, 0.0], key: "ovr", screen_size: [320.0, 240.0] };
+    let info = DynamicTextCreateInfo { max_chars: 2, text: "hi", scale: 16.0, pos: [0.0, 0.0], key: "ovr", screen_size: [320.0, 240.0], color: [1.0; 4] };
     let mut dt = DynamicText::new(&mut ctx, &mut text, &mut res, info).unwrap();
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         dt.update_text(&mut ctx, &mut res, &mut text, "toolong", 16.0, [0.0, 0.0])


### PR DESCRIPTION
## Summary
- allow specifying text color in `StaticTextCreateInfo` and `DynamicTextCreateInfo`
- encode the texture index in the tangent `w` component
- pass vertex color and texture index through the shaders
- multiply sampled glyphs by the vertex color
- update examples, tests and vertex generation helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68702cd77e04832a8d32e33314b7f87a