### PR TITLE
Add screen_size to StaticText

### DIFF
--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -68,6 +68,7 @@ pub fn run(ctx: &mut Context) {
             scale: 32.0,
             pos: [-0.9, 0.9],
             key: "glyph_tex",
+            screen_size: [320.0, 240.0],
             color: [1.0; 4],
             bold: false,
             italic: true,

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -61,7 +61,7 @@ pub fn run() {
     let font_bytes = load_system_font();
     renderer.fonts_mut().register_font("default", &font_bytes);
     let mut text = TextRenderer2D::new(renderer.fonts(), "default");
-    let info = StaticTextCreateInfo { text: "Hello", scale: 32.0, pos: [-0.5, 0.5], key: "glyph_tex", color: [1.0; 4], bold: false, italic: false };
+    let info = StaticTextCreateInfo { text: "Hello", scale: 32.0, pos: [-0.5, 0.5], key: "glyph_tex", screen_size: [320.0, 240.0], color: [1.0; 4], bold: false, italic: false };
     let mesh = StaticText::new(&mut ctx, renderer.resources(), &mut text, info).unwrap();
     renderer.register_text_mesh(mesh);
     text.register_textures(renderer.resources());

--- a/tests/text_mesh.rs
+++ b/tests/text_mesh.rs
@@ -51,6 +51,7 @@ fn static_text_new_uploads_texture() {
         scale: 16.0,
         pos: [0.0, 0.0],
         key: "stex",
+        screen_size: [320.0, 240.0],
         color: [1.0; 4],
         bold: false,
         italic: false,

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -158,7 +158,7 @@ fn static_text_preserves_gpu_buffers() {
     let mut text = TextRenderer2D::new(&registry, "default");
     let mut ctx = setup_ctx();
     let mut res = ResourceManager::default();
-    let info = StaticTextCreateInfo { text: "Hi", scale: 16.0, pos: [0.0, 0.0], key: "stex", color: [1.0; 4], bold: false, italic: false };
+    let info = StaticTextCreateInfo { text: "Hi", scale: 16.0, pos: [0.0, 0.0], key: "stex", screen_size: [320.0, 240.0], color: [1.0; 4], bold: false, italic: false };
     let mut st = StaticText::new(&mut ctx, &mut res, &mut text, info).unwrap();
     let vb = st.vertex_buffer();
     let ib = st.index_buffer().expect("ib");


### PR DESCRIPTION
## Summary
- extend `StaticTextCreateInfo` with `screen_size` for converting glyph metrics
- compute NDC scaling from `screen_size` in `StaticText::new`
- store pixel dimensions for rendered text
- update examples and tests to supply `screen_size`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68713208f518832aa5506153234fdf27