### PR TITLE
Add compute pipeline queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ buffer when their pipeline is built. The helper file
 
 No extra resource registration is necessary.
 
+## Compute Pipelines
+
+Custom compute pipelines can be added with `Renderer::register_compute_pipeline`.
+After registering, schedule work with `Renderer::queue_compute`, specifying the
+pipeline id and `[x, y, z]` workgroup counts. Queued tasks are dispatched at the
+start of the next `present_frame` call.
+
 ## Sample Binaries
 
 Example programs live under the `examples/` directory and can be run with


### PR DESCRIPTION
## Summary
- support compute pipelines and queue compute dispatches
- document new compute pipeline API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68717627a334832a98c18ee518559319