### PR TITLE
Add compute shader example with test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,7 @@ path = "examples/text2d/bin.rs"
 name = "text3d"
 path = "examples/text3d/bin.rs"
 
+[[example]]
+name = "compute_example"
+path = "examples/compute_example/bin.rs"
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,3 +18,4 @@ pull from `assets/shaders/` and rely on the uniform block provided by
 - **skeletal_animation** – play an animated skeletal mesh *(gpu_tests)*
 - **text2d** – draw 2D text using the text renderer *(gpu_tests)*
 - **text3d** – render text placed in 3-D space *(gpu_tests)*
+- **compute_example** – run a simple compute shader *(gpu_tests)*

--- a/examples/compute_example/bin.rs
+++ b/examples/compute_example/bin.rs
@@ -1,0 +1,65 @@
+use dashi::*;
+use inline_spirv::inline_spirv;
+use koji::renderer::*;
+use koji::material::ComputePipelineBuilder;
+
+fn compute_spirv() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(local_size_x = 1) in;
+        layout(set = 0, binding = 0) buffer Data { float values[]; } data;
+        layout(set = 0, binding = 1) uniform Add { float val; } addend;
+        void main() {
+            uint idx = gl_GlobalInvocationID.x;
+            data.values[idx] += addend.val;
+        }",
+        comp
+    ).to_vec()
+}
+
+#[cfg(feature = "gpu_tests")]
+pub fn run(ctx: &mut Context) {
+    let mut renderer = Renderer::new(64, 64, "compute", ctx).unwrap();
+
+    let input: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+    let buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: "compute_buffer",
+            byte_size: (input.len() * std::mem::size_of::<f32>()) as u32,
+            visibility: MemoryVisibility::CpuAndGpu,
+            usage: BufferUsage::STORAGE,
+            initial_data: Some(bytemuck::cast_slice(&input)),
+        })
+        .unwrap();
+    renderer.resources().register_storage("data", buffer);
+    renderer.resources().register_variable("addend", ctx, 2.0f32);
+
+    let shader = compute_spirv();
+    let mut pso = ComputePipelineBuilder::new(ctx, "compute_add")
+        .shader(&shader)
+        .build_with_resources(renderer.resources())
+        .unwrap();
+    let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
+    renderer.register_compute_pipeline("add", pso, bgr);
+
+    renderer.queue_compute("add", [input.len() as u32, 1, 1]);
+    renderer.present_frame().unwrap();
+
+    let slice = ctx.map_buffer::<u8>(buffer).unwrap();
+    let results: &[f32] = bytemuck::cast_slice(&slice[..input.len() * 4]);
+    println!("results: {:?}", results);
+    ctx.unmap_buffer(buffer).unwrap();
+}
+
+fn main() {
+    #[cfg(feature = "gpu_tests")]
+    {
+        let device = DeviceSelector::new()
+            .unwrap()
+            .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+            .unwrap_or_default();
+        let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+        run(&mut ctx);
+        ctx.destroy();
+    }
+}

--- a/tests/compute_pipeline.rs
+++ b/tests/compute_pipeline.rs
@@ -1,0 +1,71 @@
+use koji::renderer::*;
+use koji::material::ComputePipelineBuilder;
+use dashi::*;
+use inline_spirv::inline_spirv;
+
+fn shader() -> Vec<u32> {
+    inline_spirv!(
+        r"#version 450
+        layout(local_size_x = 1) in;
+        layout(set = 0, binding = 0) buffer Data { float values[]; } data;
+        layout(set = 0, binding = 1) uniform Add { float val; } addend;
+        void main() {
+            uint idx = gl_GlobalInvocationID.x;
+            data.values[idx] += addend.val;
+        }",
+        comp
+    ).to_vec()
+}
+
+#[cfg(feature = "gpu_tests")]
+pub fn run() {
+    let device = DeviceSelector::new()
+        .unwrap()
+        .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
+        .unwrap_or_default();
+    let mut ctx = Context::new(&ContextInfo { device }).unwrap();
+    let mut renderer = Renderer::new(64, 64, "compute_test", &mut ctx).unwrap();
+
+    let initial: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
+    let buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: "buf",
+            byte_size: (initial.len() * std::mem::size_of::<f32>()) as u32,
+            visibility: MemoryVisibility::CpuAndGpu,
+            usage: BufferUsage::STORAGE,
+            initial_data: Some(bytemuck::cast_slice(&initial)),
+        })
+        .unwrap();
+    renderer.resources().register_storage("data", buffer);
+    renderer.resources().register_variable("addend", &mut ctx, 2.0f32);
+
+    let spirv = shader();
+    let mut pso = ComputePipelineBuilder::new(&mut ctx, "test_compute")
+        .shader(&spirv)
+        .build_with_resources(renderer.resources())
+        .unwrap();
+    let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
+    renderer.register_compute_pipeline("test", pso, bgr);
+
+    renderer.queue_compute("test", [initial.len() as u32, 1, 1]);
+    renderer.present_frame().unwrap();
+
+    let slice = ctx.map_buffer::<u8>(buffer).unwrap();
+    let results: &[f32] = bytemuck::cast_slice(&slice[..initial.len() * 4]);
+    assert_eq!(results, &[3.0, 4.0, 5.0, 6.0]);
+    ctx.unmap_buffer(buffer).unwrap();
+    ctx.destroy();
+}
+
+#[cfg(all(test, feature = "gpu_tests"))]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    #[ignore]
+    fn compute_pipeline() {
+        run();
+    }
+}


### PR DESCRIPTION
## Summary
- implement a new `compute_example` demonstrating compute shader dispatch
- register the example binary in Cargo manifest and examples README
- create `compute_pipeline` test to verify compute shader buffer results

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68718f652834832ab5f05b3806752f51