### PR TITLE
Add serde debug helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "rhai",
  "rusttype",
  "serde",
+ "serde_json",
  "serde_yaml",
  "serial_test",
  "spirv-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ spirv-reflect = { git = "https://github.com/gfxstrand/spirv-reflect-rs.git" }
 serde = { version = "1.0", features = ["derive"] }
 indexmap = "2"
 serde_yaml = "0.9"
+serde_json = "1.0"
 bytemuck = { version = "1.22.0", features = ["derive"] }
 gltf = "1.4"
 rusttype = "0.9"

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -2,11 +2,25 @@ use crate::render_pass::{RenderAttachment, RenderPassBuilder, RenderTarget};
 use dashi::utils::*;
 use dashi::*;
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 
 pub struct Canvas {
     render_pass: Handle<RenderPass>,
     target: RenderTarget,
     attachments: IndexMap<String, RenderAttachment>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CanvasDesc {
+    pub attachments: Vec<String>,
+}
+
+impl From<&Canvas> for CanvasDesc {
+    fn from(c: &Canvas) -> Self {
+        Self {
+            attachments: c.attachments.keys().cloned().collect(),
+        }
+    }
 }
 
 impl Canvas {
@@ -68,9 +82,7 @@ impl CanvasBuilder {
 
     pub fn build(mut self, ctx: &mut Context) -> Result<Canvas, GPUError> {
         let sub_colors = self.color_names.clone();
-        self.builder = self
-            .builder
-            .subpass("main", sub_colors, &[] as &[&str]);
+        self.builder = self.builder.subpass("main", sub_colors, &[] as &[&str]);
         let (rp, mut targets, all) = self.builder.build_with_images(ctx)?;
         let target = targets.remove(0);
         let mut attachments = IndexMap::new();

--- a/src/render_graph/io.rs
+++ b/src/render_graph/io.rs
@@ -1,0 +1,21 @@
+use super::{RenderGraph, SerializableRenderGraph};
+
+pub fn to_yaml(graph: &RenderGraph) -> Result<String, serde_yaml::Error> {
+    let desc = SerializableRenderGraph::from(graph);
+    serde_yaml::to_string(&desc)
+}
+
+pub fn from_yaml(data: &str) -> Result<RenderGraph, serde_yaml::Error> {
+    let desc: SerializableRenderGraph = serde_yaml::from_str(data)?;
+    Ok(RenderGraph::from(desc))
+}
+
+pub fn to_json(graph: &RenderGraph) -> Result<String, serde_json::Error> {
+    let desc = SerializableRenderGraph::from(graph);
+    serde_json::to_string_pretty(&desc)
+}
+
+pub fn from_json(data: &str) -> Result<RenderGraph, serde_json::Error> {
+    let desc: SerializableRenderGraph = serde_json::from_str(data)?;
+    Ok(RenderGraph::from(desc))
+}

--- a/src/render_graph/mod.rs
+++ b/src/render_graph/mod.rs
@@ -1,16 +1,19 @@
-use std::collections::HashMap;
-use petgraph::graph::{DiGraph, NodeIndex};
-use petgraph::algo::is_cyclic_directed;
-use petgraph::visit::{Topo, EdgeRef};
 use dashi::utils::*;
 use dashi::*;
+use petgraph::algo::is_cyclic_directed;
+use petgraph::graph::{DiGraph, NodeIndex};
+use petgraph::visit::{EdgeRef, Topo};
+use std::collections::HashMap;
 
 use dashi::gpu::RenderPass;
+use serde::{Deserialize, Serialize};
 
 mod composition;
 pub use composition::*;
+pub mod io;
+pub use io::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ResourceDesc {
     pub name: String,
     pub format: Format,
@@ -31,8 +34,18 @@ pub struct RenderPassNode {
 }
 
 impl RenderPassNode {
-    pub fn new(name: impl Into<String>, pass: Handle<RenderPass>, inputs: Vec<ResourceDesc>, outputs: Vec<ResourceDesc>) -> Self {
-        Self { name: name.into(), pass, inputs, outputs }
+    pub fn new(
+        name: impl Into<String>,
+        pass: Handle<RenderPass>,
+        inputs: Vec<ResourceDesc>,
+        outputs: Vec<ResourceDesc>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            pass,
+            inputs,
+            outputs,
+        }
     }
 
     pub fn geometry(pass: Handle<RenderPass>) -> Self {
@@ -45,9 +58,15 @@ impl RenderPassNode {
 }
 
 impl GraphNode for RenderPassNode {
-    fn name(&self) -> &str { &self.name }
-    fn inputs(&self) -> Vec<ResourceDesc> { self.inputs.clone() }
-    fn outputs(&self) -> Vec<ResourceDesc> { self.outputs.clone() }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn inputs(&self) -> Vec<ResourceDesc> {
+        self.inputs.clone()
+    }
+    fn outputs(&self) -> Vec<ResourceDesc> {
+        self.outputs.clone()
+    }
     fn execute(&mut self, _ctx: &mut Context) -> Result<(), GPUError> {
         // In a full implementation this would record commands for the render pass
         let _ = self.pass; // silence unused field
@@ -62,17 +81,29 @@ pub struct ExternalImageNode {
 
 impl ExternalImageNode {
     pub fn new(name: impl Into<String>, format: Format) -> Self {
-        Self { name: name.into(), format }
+        Self {
+            name: name.into(),
+            format,
+        }
     }
 }
 
 impl GraphNode for ExternalImageNode {
-    fn name(&self) -> &str { &self.name }
-    fn inputs(&self) -> Vec<ResourceDesc> { Vec::new() }
-    fn outputs(&self) -> Vec<ResourceDesc> {
-        vec![ResourceDesc { name: self.name.clone(), format: self.format }]
+    fn name(&self) -> &str {
+        &self.name
     }
-    fn execute(&mut self, _ctx: &mut Context) -> Result<(), GPUError> { Ok(()) }
+    fn inputs(&self) -> Vec<ResourceDesc> {
+        Vec::new()
+    }
+    fn outputs(&self) -> Vec<ResourceDesc> {
+        vec![ResourceDesc {
+            name: self.name.clone(),
+            format: self.format,
+        }]
+    }
+    fn execute(&mut self, _ctx: &mut Context) -> Result<(), GPUError> {
+        Ok(())
+    }
 }
 
 pub struct RenderGraph {
@@ -80,9 +111,56 @@ pub struct RenderGraph {
     indices: HashMap<String, NodeIndex>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GraphNodeDesc {
+    pub name: String,
+    pub inputs: Vec<ResourceDesc>,
+    pub outputs: Vec<ResourceDesc>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SerializableRenderGraph {
+    pub nodes: Vec<GraphNodeDesc>,
+    pub edges: Vec<(String, String)>,
+}
+
+pub struct SimpleNode {
+    name: String,
+    inputs: Vec<ResourceDesc>,
+    outputs: Vec<ResourceDesc>,
+}
+
+impl From<GraphNodeDesc> for SimpleNode {
+    fn from(desc: GraphNodeDesc) -> Self {
+        Self {
+            name: desc.name,
+            inputs: desc.inputs,
+            outputs: desc.outputs,
+        }
+    }
+}
+
+impl GraphNode for SimpleNode {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn inputs(&self) -> Vec<ResourceDesc> {
+        self.inputs.clone()
+    }
+    fn outputs(&self) -> Vec<ResourceDesc> {
+        self.outputs.clone()
+    }
+    fn execute(&mut self, _ctx: &mut Context) -> Result<(), GPUError> {
+        Ok(())
+    }
+}
+
 impl RenderGraph {
     pub fn new() -> Self {
-        Self { graph: DiGraph::new(), indices: HashMap::new() }
+        Self {
+            graph: DiGraph::new(),
+            indices: HashMap::new(),
+        }
     }
 
     pub fn add_node<N: GraphNode + 'static>(&mut self, node: N) {
@@ -130,5 +208,75 @@ impl RenderGraph {
         }
         Ok(())
     }
+
+    pub fn node_names(&self) -> Vec<String> {
+        self.graph
+            .node_indices()
+            .map(|i| self.graph[i].name().to_string())
+            .collect()
+    }
+
+    pub fn edges(&self) -> Vec<(String, String)> {
+        self.graph
+            .edge_references()
+            .map(|e| {
+                let a = self.graph[e.source()].name().to_string();
+                let b = self.graph[e.target()].name().to_string();
+                (a, b)
+            })
+            .collect()
+    }
+
+    pub fn output_images(&self) -> Vec<String> {
+        self.graph
+            .node_indices()
+            .flat_map(|i| {
+                self.graph[i]
+                    .outputs()
+                    .into_iter()
+                    .map(|r| r.name)
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
 }
 
+impl From<&RenderGraph> for SerializableRenderGraph {
+    fn from(g: &RenderGraph) -> Self {
+        let nodes = g
+            .graph
+            .node_indices()
+            .map(|i| {
+                let node = &g.graph[i];
+                GraphNodeDesc {
+                    name: node.name().to_string(),
+                    inputs: node.inputs(),
+                    outputs: node.outputs(),
+                }
+            })
+            .collect();
+        let edges = g
+            .graph
+            .edge_references()
+            .map(|e| {
+                let a = g.graph[e.source()].name().to_string();
+                let b = g.graph[e.target()].name().to_string();
+                (a, b)
+            })
+            .collect();
+        Self { nodes, edges }
+    }
+}
+
+impl From<SerializableRenderGraph> for RenderGraph {
+    fn from(desc: SerializableRenderGraph) -> Self {
+        let mut g = RenderGraph::new();
+        for n in desc.nodes {
+            g.add_node(SimpleNode::from(n));
+        }
+        for (a, b) in desc.edges {
+            g.connect(&a, &b);
+        }
+        g
+    }
+}

--- a/tests/render_graph.rs
+++ b/tests/render_graph.rs
@@ -1,6 +1,6 @@
-use koji::render_graph::{RenderGraph, ResourceDesc, CompositionNode, GraphNode};
 use dashi::gpu;
 use dashi::*;
+use koji::render_graph::{CompositionNode, GraphNode, RenderGraph, ResourceDesc};
 use serial_test::serial;
 
 fn setup_ctx() -> gpu::Context {
@@ -11,7 +11,10 @@ fn setup_ctx() -> gpu::Context {
 #[serial]
 fn composition_node_registers_inputs() {
     let node = CompositionNode::new(
-        vec![ResourceDesc { name: "a".into(), format: Format::RGBA8 }],
+        vec![ResourceDesc {
+            name: "a".into(),
+            format: Format::RGBA8,
+        }],
         Format::BGRA8,
     );
     assert_eq!(node.inputs().len(), 1);
@@ -25,11 +28,23 @@ fn render_graph_executes_with_composition() {
     let mut graph = RenderGraph::new();
     graph.register_external_image("input", Format::RGBA8);
     let node = CompositionNode::new(
-        vec![ResourceDesc { name: "input".into(), format: Format::RGBA8 }],
+        vec![ResourceDesc {
+            name: "input".into(),
+            format: Format::RGBA8,
+        }],
         Format::BGRA8,
     );
     graph.add_node(node);
     graph.connect("input", "composition");
     graph.execute(&mut ctx).unwrap();
     ctx.destroy();
+}
+
+#[test]
+fn graph_yaml_roundtrip() {
+    let mut graph = RenderGraph::new();
+    graph.register_external_image("img", Format::RGBA8);
+    let yaml = koji::render_graph::to_yaml(&graph).unwrap();
+    let loaded = koji::render_graph::from_yaml(&yaml).unwrap();
+    assert_eq!(graph.node_names(), loaded.node_names());
 }


### PR DESCRIPTION
## Summary
- add JSON and YAML helpers for render graph
- implement CanvasDesc for serialization
- expose node queries and graph serialization
- test roundtrip for render graph YAML

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687a90f20cf8832a88fc02dcb87fe3e5