### PR TITLE
Support canvas and render graph targets for pipelines

### DIFF
--- a/examples/bindless_rendering/bin.rs
+++ b/examples/bindless_rendering/bin.rs
@@ -32,7 +32,7 @@ pub fn run(ctx: &mut Context) {
     let mut pso = PipelineBuilder::new(ctx, "bindless")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(renderer.render_pass(), 0)
+        .render_pass((renderer.render_pass(), 0))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -17,7 +17,7 @@ fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -
     PipelineBuilder::new(ctx, "pbr")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(rp, subpass)
+        .render_pass((rp, subpass))
         .depth_enable(true)
         .cull_mode(CullMode::Back)
         .build()

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -40,7 +40,7 @@ pub fn run(ctx: &mut Context) {
     let mut pso = PipelineBuilder::new(ctx, "sample_pso")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(renderer.render_pass(), 0)
+        .render_pass((renderer.render_pass(), 0))
         .build_with_resources(renderer.resources())
         .unwrap();
 

--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -105,7 +105,7 @@ pub fn run(ctx: &mut Context) {
     let mut pso = PipelineBuilder::new(ctx, "text_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass(renderer.render_pass(), 0)
+        .render_pass((renderer.render_pass(), 0))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();

--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -56,7 +56,7 @@ pub fn run(ctx: &mut Context) {
     let mut pso = PipelineBuilder::new(ctx, "text3d_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass(renderer.render_pass(), 0)
+        .render_pass((renderer.render_pass(), 0))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -39,6 +39,10 @@ impl Canvas {
     pub fn view(&self, name: &str) -> Option<Handle<ImageView>> {
         self.attachments.get(name).map(|a| a.attachment.img)
     }
+
+    pub fn format(&self, name: &str) -> Option<Format> {
+        self.attachments.get(name).map(|a| a.format)
+    }
 }
 
 #[derive(Default)]

--- a/src/material/bindless_lighting.rs
+++ b/src/material/bindless_lighting.rs
@@ -135,7 +135,7 @@ mod tests {
         let mut pso = PipelineBuilder::new(&mut ctx, "light_test")
             .vertex_shader(&vert)
             .fragment_shader(&frag)
-            .render_pass(rp, 0)
+            .render_pass((rp, 0))
             .build();
 
         let mut lights = BindlessLights::new();

--- a/src/material/pipeline_builder_tests.rs
+++ b/src/material/pipeline_builder_tests.rs
@@ -62,7 +62,7 @@ fn builder_with_no_descriptors_creates_pipeline() {
     let pipeline = PipelineBuilder::new(&mut ctx, "test_no_desc")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 
     assert!(pipeline.pipeline.valid());
@@ -137,7 +137,7 @@ fn out_of_range_descriptor_set_panics() {
     let _ = PipelineBuilder::new(&mut ctx, "oops")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
     ctx.destroy();
 }
@@ -168,7 +168,7 @@ fn empty_descriptor_name_panics() {
     let _ = PipelineBuilder::new(&mut ctx, "empty_name")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 }
 
@@ -207,7 +207,7 @@ fn duplicate_descriptor_name_panics() {
     let _ = PipelineBuilder::new(&mut ctx, "dup_name")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 }
 
@@ -315,7 +315,7 @@ fn pipeline_builder_and_bind_group() {
     let mut pso = PipelineBuilder::new(&mut ctx, "pso_test")
         .vertex_shader(&simple_vert2())
         .fragment_shader(&simple_frag2())
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 
     let mut resources = ResourceManager::new(&mut ctx, 1024).unwrap();
@@ -382,7 +382,7 @@ fn bindless_texture_array_in_shader() {
     let mut pso = PipelineBuilder::new(&mut ctx, "pso_bindless_test")
         .vertex_shader(&vert_spirv)
         .fragment_shader(&frag_spirv)
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 
     let sampler = ctx.make_sampler(&Default::default()).unwrap();
@@ -460,7 +460,7 @@ fn multiple_bindless_bindings_in_shader() {
     let mut pso = PipelineBuilder::new(&mut ctx, "bindless_combined_and_buffer_array_test")
         .vertex_shader(&vert_spirv)
         .fragment_shader(&frag_spirv)
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 
     let mut combined_array = ResourceList::<CombinedTextureSampler>::default();
@@ -567,7 +567,7 @@ fn create_bind_group_missing_resource() {
     let mut pso = PipelineBuilder::new(&mut ctx, "missing")
         .vertex_shader(&simple_vert2())
         .fragment_shader(&simple_frag2())
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 
     let mut res = ResourceManager::new(&mut ctx, 1024).unwrap();
@@ -597,7 +597,7 @@ fn build_with_resources_missing_resource() {
     let result = PipelineBuilder::new(&mut ctx, "build_missing")
         .vertex_shader(&simple_vert2())
         .fragment_shader(&simple_frag2())
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build_with_resources(&mut res);
 
     match result {
@@ -620,7 +620,7 @@ fn create_bind_groups_multiple_sets() {
     let mut pso = PipelineBuilder::new(&mut ctx, "multi_set")
         .vertex_shader(&multi_set_vert())
         .fragment_shader(&multi_set_frag())
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 
     let mut res = ResourceManager::new(&mut ctx, 2048).unwrap();
@@ -681,7 +681,7 @@ fn auto_register_time_resource() {
     let mut pso = PipelineBuilder::new(&mut ctx, "time_test")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build_with_resources(&mut res)
         .unwrap();
 
@@ -707,7 +707,7 @@ fn large_indexed_array_bindings() {
     let mut pso = PipelineBuilder::new(&mut ctx, "large_array")
         .vertex_shader(&simple_vertex_spirv())
         .fragment_shader(&large_array_frag())
-        .render_pass(rp, 0)
+        .render_pass((rp, 0))
         .build();
 
     let sampler = ctx.make_sampler(&SamplerInfo::default()).unwrap();

--- a/src/material/skin_pipeline.rs
+++ b/src/material/skin_pipeline.rs
@@ -8,6 +8,6 @@ pub fn build_skinning_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpas
     PipelineBuilder::new(ctx, "skinning_pipeline")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(rp, subpass)
+        .render_pass((rp, subpass))
         .build()
 }

--- a/src/render_graph/composition.rs
+++ b/src/render_graph/composition.rs
@@ -47,4 +47,7 @@ impl GraphNode for CompositionNode {
         // that blends all inputs into the swapchain image according to `mode`.
         Ok(())
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -32,6 +32,7 @@ pub struct AllRenderAttachments {
 #[derive(Clone)]
 pub struct RenderAttachment {
     pub name: String,
+    pub format: Format,
     pub attachment: Attachment,
 }
 
@@ -269,6 +270,7 @@ impl RenderPassBuilder {
                 name.clone(),
                 RenderAttachment {
                     name: name.clone(),
+                    format: att.format,
                     attachment,
                 },
             );

--- a/tests/bindless_lighting.rs
+++ b/tests/bindless_lighting.rs
@@ -33,7 +33,7 @@ pub fn run() {
     let mut pso = PipelineBuilder::new(&mut ctx, "lights")
         .vertex_shader(&vert())
         .fragment_shader(&frag())
-        .render_pass(renderer.render_pass(),0)
+        .render_pass((renderer.render_pass(), 0))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/tests/bindless_rendering.rs
+++ b/tests/bindless_rendering.rs
@@ -35,7 +35,7 @@ pub fn run() {
     let mut pso = PipelineBuilder::new(&mut ctx, "bindless")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(renderer.render_pass(),0)
+        .render_pass((renderer.render_pass(), 0))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/tests/custom_pass.rs
+++ b/tests/custom_pass.rs
@@ -39,7 +39,7 @@ subpasses:
     let mut pso_first = PipelineBuilder::new(&mut ctx, "first_pso")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(renderer.render_pass(), 0)
+        .render_pass((renderer.render_pass(), 0))
         .build();
     let bgr_first = pso_first.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("first", pso_first, bgr_first);
@@ -47,7 +47,7 @@ subpasses:
     let mut pso_second = PipelineBuilder::new(&mut ctx, "second_pso")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(renderer.render_pass(), 1)
+        .render_pass((renderer.render_pass(), 1))
         .build();
     let bgr_second = pso_second.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("second", pso_second, bgr_second);

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -32,7 +32,7 @@ fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -
     PipelineBuilder::new(ctx, "pbr_pipeline")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(rp, subpass)
+        .render_pass((rp, subpass))
         .depth_enable(true)
         .cull_mode(CullMode::Back)
         .build()

--- a/tests/pbr_texture_loading.rs
+++ b/tests/pbr_texture_loading.rs
@@ -37,7 +37,7 @@ fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -
     PipelineBuilder::new(ctx, "pbr_pipeline")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(rp, subpass)
+        .render_pass((rp, subpass))
         .depth_enable(true)
         .cull_mode(CullMode::Back)
         .build()

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -93,7 +93,7 @@ fn render_triangle_and_cube() {
     let mut pso = PipelineBuilder::new(&mut ctx, "triangle_cube_pipeline")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass(renderer.render_pass(), 0)
+        .render_pass((renderer.render_pass(), 0))
         .build();
 
     // Generate/cached bind group resources for all sets

--- a/tests/static_movement.rs
+++ b/tests/static_movement.rs
@@ -36,7 +36,7 @@ pub fn run() {
     let mut pso = PipelineBuilder::new(&mut ctx,"move_pso")
         .vertex_shader(&vert())
         .fragment_shader(&frag())
-        .render_pass(renderer.render_pass(),0)
+        .render_pass((renderer.render_pass(), 0))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -71,7 +71,7 @@ pub fn run() {
     let mut pso = PipelineBuilder::new(&mut ctx, "text_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass(renderer.render_pass(), 0)
+        .render_pass((renderer.render_pass(), 0))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();


### PR DESCRIPTION
## Summary
- enable `PipelineBuilder::render_pass` to accept canvas attachments or render graph outputs
- validate attachment formats and return meaningful errors
- expose canvas attachment format info
- test new API via updated examples and unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687aa0ba1a90832aa6c8c10eaed8d421