### PR TITLE
Add CanvasDesc YAML/JSON IO helpers

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -4,6 +4,9 @@ use dashi::*;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
+pub mod io;
+pub use io::*;
+
 #[derive(Clone)]
 pub struct Canvas {
     render_pass: Handle<RenderPass>,

--- a/src/canvas/io.rs
+++ b/src/canvas/io.rs
@@ -1,0 +1,17 @@
+use super::CanvasDesc;
+
+pub fn to_yaml(desc: &CanvasDesc) -> Result<String, serde_yaml::Error> {
+    serde_yaml::to_string(desc)
+}
+
+pub fn from_yaml(data: &str) -> Result<CanvasDesc, serde_yaml::Error> {
+    serde_yaml::from_str(data)
+}
+
+pub fn to_json(desc: &CanvasDesc) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(desc)
+}
+
+pub fn from_json(data: &str) -> Result<CanvasDesc, serde_json::Error> {
+    serde_json::from_str(data)
+}

--- a/tests/canvas_io.rs
+++ b/tests/canvas_io.rs
@@ -1,0 +1,17 @@
+use koji::canvas::{CanvasDesc, to_yaml, from_yaml, to_json, from_json};
+
+#[test]
+fn canvas_yaml_roundtrip() {
+    let desc = CanvasDesc { attachments: vec!["color".into(), "depth".into()] };
+    let yaml = to_yaml(&desc).unwrap();
+    let loaded = from_yaml(&yaml).unwrap();
+    assert_eq!(desc.attachments, loaded.attachments);
+}
+
+#[test]
+fn canvas_json_roundtrip() {
+    let desc = CanvasDesc { attachments: vec!["color".into()] };
+    let json = to_json(&desc).unwrap();
+    let loaded = from_json(&json).unwrap();
+    assert_eq!(desc.attachments, loaded.attachments);
+}


### PR DESCRIPTION
## Summary
- add `canvas/io.rs` with YAML and JSON helpers
- re-export the IO helpers from `canvas.rs`
- test CanvasDesc YAML and JSON roundtrips

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687bc5c3e514832a91092315ae4dbed1