### PR TITLE
Add render graph YAML/JSON examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Render passes can now be described with a [`RenderGraph`](src/render_graph/mod.r
 `#[deprecated]`. Prefer constructing graph nodes and connecting them
 to form the frame pipeline.
 
+Example descriptions of a lightweight graph can be found in
+[examples/graph_basic.yaml](examples/graph_basic.yaml) and
+[examples/graph_basic.json](examples/graph_basic.json). These files
+demonstrate a simple `geometry -> sky -> compose` pipeline.
+
 ## Sample Binaries
 
 Example programs live under the `examples/` directory and can be run with

--- a/examples/graph_basic.json
+++ b/examples/graph_basic.json
@@ -1,0 +1,33 @@
+{
+  "nodes": [
+    {
+      "name": "geometry",
+      "inputs": [],
+      "outputs": [
+        { "name": "geom_color", "format": "RGBA8" }
+      ]
+    },
+    {
+      "name": "sky",
+      "inputs": [
+        { "name": "geom_color", "format": "RGBA8" }
+      ],
+      "outputs": [
+        { "name": "sky_color", "format": "RGBA8" }
+      ]
+    },
+    {
+      "name": "compose",
+      "inputs": [
+        { "name": "sky_color", "format": "RGBA8" }
+      ],
+      "outputs": [
+        { "name": "swapchain", "format": "BGRA8" }
+      ]
+    }
+  ],
+  "edges": [
+    ["geometry", "sky"],
+    ["sky", "compose"]
+  ]
+}

--- a/examples/graph_basic.yaml
+++ b/examples/graph_basic.yaml
@@ -1,0 +1,23 @@
+nodes:
+  - name: geometry
+    inputs: []
+    outputs:
+      - name: geom_color
+        format: RGBA8
+  - name: sky
+    inputs:
+      - name: geom_color
+        format: RGBA8
+    outputs:
+      - name: sky_color
+        format: RGBA8
+  - name: compose
+    inputs:
+      - name: sky_color
+        format: RGBA8
+    outputs:
+      - name: swapchain
+        format: BGRA8
+edges:
+  - [geometry, sky]
+  - [sky, compose]


### PR DESCRIPTION
## Summary
- add `graph_basic.yaml` and `graph_basic.json` under `examples/`
- document sample graph files in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687be97b7928832abe903ec7064108b2