### PR TITLE
Add render graph documentation

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,3 +1,12 @@
+//! Abstractions for constructing offscreen render targets.
+//!
+//! A [`Canvas`] bundles a [`RenderPass`] and its attachments so that it can be
+//! inserted into a [`crate::RenderGraph`]. [`crate::CanvasBuilder`] is a small
+//! wrapper around [`crate::RenderPassBuilder`] that simplifies the creation of
+//! these passes. The
+//! resulting `Canvas` exposes its attachments for pipeline creation and can be
+//! connected to other graph nodes.
+
 use crate::render_pass::{RenderAttachment, RenderPassBuilder, RenderTarget};
 use dashi::utils::*;
 use dashi::*;

--- a/src/render_graph/mod.rs
+++ b/src/render_graph/mod.rs
@@ -1,7 +1,13 @@
 //! Utilities for constructing render graphs.
 //!
-//! [`CanvasNode`] wraps a [`Canvas`] and can be inserted via
-//! [`RenderGraph::add_canvas`]. Canvas attachments become graph outputs for
+//! A [`crate::RenderGraph`] is built from nodes that produce or consume images.
+//! Nodes are commonly created from [`crate::RenderPassBuilder`] and
+//! [`crate::CanvasBuilder`], which generate [`RenderPassNode`] and
+//! [`CanvasNode`] entries respectively. The resulting graph describes execution
+//! order and resource flow between passes. A [`CompositionNode`] can then
+//! combine multiple outputs into the swapchain. [`CanvasNode`] wraps a
+//! [`Canvas`] and can be inserted via [`RenderGraph::add_canvas`]. Canvas
+//! attachments become graph outputs for
 //! pipeline creation.
 
 use dashi::utils::*;


### PR DESCRIPTION
## Summary
- document purpose of `Canvas` and how to use `CanvasBuilder`
- explain relationships between `RenderGraph`, `CompositionNode`, and builders

## Testing
- `cargo test`
- `cargo doc`

------
https://chatgpt.com/codex/tasks/task_e_687be993a924832a8ae9dc3f86556e1d