### PR TITLE
gate gpu tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ petgraph = "0.6"
 serial_test = "2.0"
 
 [features]
+# Enable integration tests that require a Vulkan-capable GPU
 gpu_tests = []
 large-tests = []
 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ See [examples/README.md](examples/README.md) for more information.
 ## Contributing
 
 Before submitting a pull request, run `cargo test` and ensure it completes successfully.
+
+Some integration tests require a Vulkan-capable GPU. Enable them with:
+
+```bash
+cargo test --features gpu_tests
+```

--- a/src/material/bindless.rs
+++ b/src/material/bindless.rs
@@ -37,7 +37,7 @@ impl BindlessData {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gpu_tests"))]
 mod tests {
     use super::*;
     use dashi::gpu;

--- a/src/material/mod.rs
+++ b/src/material/mod.rs
@@ -7,7 +7,7 @@ pub mod bindless;
 pub mod bindless_lighting;
 pub mod skin_pipeline;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gpu_tests"))]
 mod pipeline_builder_tests;
 #[cfg(test)]
 mod shader_reflection_tests;

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -452,7 +452,7 @@ impl From<RenderPassBuilder> for Box<dyn GraphNode> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gpu_tests"))]
 mod tests {
     use super::*;
     use dashi::gpu;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -809,7 +809,6 @@ mod tests {
 
     #[test]
     #[serial]
-    #[ignore]
     #[cfg_attr(not(feature = "gpu_tests"), ignore)]
     fn set_clear_color_updates_attachments() {
         let device = gpu::DeviceSelector::new()
@@ -834,7 +833,6 @@ mod tests {
 
     #[test]
     #[serial]
-    #[ignore]
     #[cfg_attr(not(feature = "gpu_tests"), ignore)]
     fn set_clear_depth_updates_attachments() {
         let device = gpu::DeviceSelector::new()

--- a/src/utils/allocator.rs
+++ b/src/utils/allocator.rs
@@ -131,7 +131,7 @@ impl GpuAllocator {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gpu_tests"))]
 mod test {
     use super::*;
     use dashi::gpu;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -272,7 +272,7 @@ impl ResourceManager {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gpu_tests"))]
 mod tests {
     use super::*;
     use dashi::gpu;

--- a/tests/render_graph.rs
+++ b/tests/render_graph.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "gpu_tests")]
+
 use dashi::gpu;
 use dashi::*;
 use koji::canvas::CanvasBuilder;

--- a/tests/texture_manager.rs
+++ b/tests/texture_manager.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "gpu_tests")]
+
 use koji::texture_manager::{load_from_bytes, free_texture};
 use koji::utils::{ResourceManager, ResourceBinding, Texture};
 use dashi::gpu;

--- a/tests/time_stats.rs
+++ b/tests/time_stats.rs
@@ -23,7 +23,6 @@ fn update_tracks_elapsed_and_delta() {
 
 #[test]
 #[serial]
-#[ignore]
 #[cfg_attr(not(feature = "gpu_tests"), ignore)]
 fn renderer_updates_time_buffer() {
     let device = gpu::DeviceSelector::new()


### PR DESCRIPTION
## Summary
- conditionally compile gpu-dependent tests under a `gpu_tests` feature
- document how to enable gpu tests in README
- describe `gpu_tests` feature in Cargo.toml

## Testing
- `cargo test` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687be995b4b0832a9a4da4e7c8695731