### PR TITLE
Refactor tests for RenderGraph initialization

### DIFF
--- a/tests/bindless_lighting.rs
+++ b/tests/bindless_lighting.rs
@@ -1,5 +1,8 @@
 use koji::material::*;
 use koji::renderer::*;
+use koji::canvas::CanvasBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 use inline_spirv::inline_spirv;
 
@@ -28,12 +31,27 @@ pub fn run() {
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo{ device }).unwrap();
-    let mut renderer = Renderer::new(320,240,"lights", &mut ctx).unwrap();
+
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
+    renderer.add_canvas(canvas);
 
     let mut pso = PipelineBuilder::new(&mut ctx, "lights")
         .vertex_shader(&vert())
         .fragment_shader(&frag())
-        .render_pass((renderer.render_pass(), 0))
+        .render_pass(graph.output("color"))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/tests/bindless_rendering.rs
+++ b/tests/bindless_rendering.rs
@@ -1,5 +1,8 @@
 use koji::material::*;
 use koji::renderer::*;
+use koji::canvas::CanvasBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 
 use inline_spirv::inline_spirv;
@@ -28,14 +31,29 @@ pub fn run() {
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo{ device }).unwrap();
-    let mut renderer = Renderer::new(320,240,"bindless", &mut ctx).unwrap();
+
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
+    renderer.add_canvas(canvas);
 
     let vert = simple_vert();
     let frag = simple_frag();
     let mut pso = PipelineBuilder::new(&mut ctx, "bindless")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass((renderer.render_pass(), 0))
+        .render_pass(graph.output("color"))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/tests/compute_pipeline.rs
+++ b/tests/compute_pipeline.rs
@@ -1,4 +1,7 @@
 use koji::renderer::*;
+use koji::canvas::CanvasBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use koji::material::ComputePipelineBuilder;
 use dashi::*;
 use inline_spirv::inline_spirv;
@@ -24,7 +27,22 @@ pub fn run() {
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo { device }).unwrap();
-    let mut renderer = Renderer::new(64, 64, "compute_test", &mut ctx).unwrap();
+
+    let canvas = CanvasBuilder::new()
+        .extent([64, 64])
+        .color_attachment("color", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(64, 64, &mut ctx, builder).unwrap();
+    renderer.add_canvas(canvas);
 
     let initial: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
     let buffer = ctx

--- a/tests/skeletal_animation.rs
+++ b/tests/skeletal_animation.rs
@@ -1,8 +1,12 @@
 use koji::renderer::*;
 use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
-use koji::animation::{Animator};
+use koji::animation::Animator;
 use koji::animation::clip::AnimationPlayer;
+use koji::canvas::CanvasBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
+use inline_spirv::include_spirv;
 use dashi::*;
 
 #[cfg(feature = "gpu_tests")]
@@ -11,7 +15,22 @@ pub fn run() {
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo{ device }).unwrap();
-    let mut renderer = Renderer::new(320,240,"anim", &mut ctx).unwrap();
+
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
+    renderer.add_canvas(canvas);
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh { MeshData::Skeletal(m) => m.clone(), _ => panic!("expected skel") };
@@ -21,7 +40,13 @@ pub fn run() {
     let instance = SkeletalInstance::with_player(&mut ctx, animator, player).unwrap();
     renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
-    let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(),0);
+    let vert: &[u32] = include_spirv!("src/renderer/skinning.vert", vert, glsl);
+    let frag: &[u32] = include_spirv!("src/renderer/skinning.frag", frag, glsl);
+    let mut pso = PipelineBuilder::new(&mut ctx, "skinning_pipeline")
+        .vertex_shader(vert)
+        .fragment_shader(frag)
+        .render_pass(graph.output("color"))
+        .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso,bgr);
 

--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -1,8 +1,12 @@
 use koji::renderer::*;
 use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
+use koji::canvas::CanvasBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use glam::Mat4;
 use koji::animation::Animator;
+use inline_spirv::include_spirv;
 use dashi::*;
 
 #[cfg(feature = "gpu_tests")]
@@ -12,7 +16,22 @@ pub fn run_simple_skeleton() {
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo { device }).unwrap();
-    let mut renderer = Renderer::new(320, 240, "skin", &mut ctx).unwrap();
+
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
+    renderer.add_canvas(canvas);
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh {
@@ -23,7 +42,13 @@ pub fn run_simple_skeleton() {
     let instance = SkeletalInstance::new(&mut ctx, Animator::new(mesh.skeleton.clone())).unwrap();
     renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
-    let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
+    let vert: &[u32] = include_spirv!("src/renderer/skinning.vert", vert, glsl);
+    let frag: &[u32] = include_spirv!("src/renderer/skinning.frag", frag, glsl);
+    let mut pso = PipelineBuilder::new(&mut ctx, "skinning_pipeline")
+        .vertex_shader(vert)
+        .fragment_shader(frag)
+        .render_pass(graph.output("color"))
+        .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso, bgr);
 
@@ -40,7 +65,21 @@ pub fn run_update_bones_twice() {
         .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
         .unwrap_or_default();
     let mut ctx = Context::new(&ContextInfo { device }).unwrap();
-    let mut renderer = Renderer::new(320, 240, "skin", &mut ctx).unwrap();
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
+    renderer.add_canvas(canvas);
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh {
@@ -51,7 +90,13 @@ pub fn run_update_bones_twice() {
     let instance = SkeletalInstance::new(&mut ctx, Animator::new(mesh.skeleton.clone())).unwrap();
     renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
-    let mut pso = build_skinning_pipeline(&mut ctx, renderer.render_pass(), 0);
+    let vert: &[u32] = include_spirv!("src/renderer/skinning.vert", vert, glsl);
+    let frag: &[u32] = include_spirv!("src/renderer/skinning.frag", frag, glsl);
+    let mut pso = PipelineBuilder::new(&mut ctx, "skinning_pipeline")
+        .vertex_shader(vert)
+        .fragment_shader(frag)
+        .render_pass(graph.output("color"))
+        .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso, bgr);
 

--- a/tests/time_stats.rs
+++ b/tests/time_stats.rs
@@ -2,6 +2,9 @@ use koji::renderer::TimeStats;
 use std::time::Duration;
 use koji::renderer::Renderer;
 use koji::utils::ResourceBinding;
+use koji::canvas::CanvasBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use dashi::gpu;
 use serial_test::serial;
 
@@ -30,7 +33,22 @@ fn renderer_updates_time_buffer() {
         .select(gpu::DeviceFilter::default().add_required_type(gpu::DeviceType::Dedicated))
         .unwrap_or_default();
     let mut ctx = gpu::Context::new(&gpu::ContextInfo { device }).unwrap();
-    let mut renderer = Renderer::new(64, 64, "time", &mut ctx).unwrap();
+
+    let canvas = CanvasBuilder::new()
+        .extent([64, 64])
+        .color_attachment("color", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(64, 64, &mut ctx, builder).unwrap();
+    renderer.add_canvas(canvas);
 
     renderer.present_frame().unwrap();
     std::thread::sleep(Duration::from_millis(5));

--- a/tests/time_stats.rs
+++ b/tests/time_stats.rs
@@ -6,6 +6,7 @@ use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
 use koji::render_pass::RenderPassBuilder;
 use dashi::gpu;
+use dashi::Format;
 use serial_test::serial;
 
 #[test]


### PR DESCRIPTION
## Summary
- use `CanvasBuilder` and `RenderGraph` when constructing renderers in gpu tests
- create render pipelines from graph outputs

## Testing
- `cargo test --features gpu_tests` *(failed: could not finish building due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687d133ef208832a81ef04e925c1d04a