### PR TITLE
Fix render pass usage in present_frame

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -516,7 +516,6 @@ impl Renderer {
                     atts
                 };
 
-                let mut started = false;
                 for (_idx, (mesh, _dynamic_buffers)) in self.drawables.iter().enumerate() {
                     let (pso, bind_groups) =
                         if let Some(entry) = self.material_pipelines.get(&mesh.material_id) {
@@ -526,50 +525,24 @@ impl Renderer {
                         } else {
                             continue;
                         };
-                    if !started {
-                        list.begin_drawing(&DrawBegin {
-                            viewport: Viewport {
-                                area: FRect2D {
-                                    w: self.width as f32,
-                                    h: self.height as f32,
-                                    ..Default::default()
-                                },
-                                scissor: Rect2D {
-                                    w: self.width,
-                                    h: self.height,
-                                    ..Default::default()
-                                },
+                    list.begin_drawing(&DrawBegin {
+                        viewport: Viewport {
+                            area: FRect2D {
+                                w: self.width as f32,
+                                h: self.height as f32,
                                 ..Default::default()
                             },
-                            pipeline: pso.pipeline,
-                            attachments: &attachments,
-                        })
-                        .unwrap();
-                        started = true;
-                    } else {
-                        list.begin_drawing(&DrawBegin {
-                            viewport: Viewport {
-                                area: FRect2D {
-                                    w: self.width as f32,
-                                    h: self.height as f32,
-                                    ..Default::default()
-                                },
-                                scissor: Rect2D {
-                                    w: self.width,
-                                    h: self.height,
-                                    ..Default::default()
-                                },
+                            scissor: Rect2D {
+                                w: self.width,
+                                h: self.height,
                                 ..Default::default()
                             },
-                            pipeline: pso.pipeline,
-                            attachments: &target
-                                .colors
-                                .iter()
-                                .map(|a| a.attachment)
-                                .collect::<Vec<_>>(),
-                        })
-                        .unwrap();
-                    }
+                            ..Default::default()
+                        },
+                        pipeline: pso.pipeline,
+                        attachments: &attachments,
+                    })
+                    .unwrap();
 
                     let vb = mesh.vertex_buffer.expect("Vertex buffer missing");
                     let ib = mesh.index_buffer;
@@ -602,8 +575,6 @@ impl Renderer {
                         })
                     };
                     list.append(draw);
-                }
-                if started {
                     list.end_drawing().unwrap();
                 }
 
@@ -678,7 +649,6 @@ impl Renderer {
                             continue;
                         };
                     let layout = pso.bind_group_layouts[0].expect("layout");
-                    let mut started = false;
                     for inst in instances.iter_mut() {
                         inst.update_gpu(ctx).unwrap();
                         let inst_bg = ctx
@@ -693,54 +663,28 @@ impl Renderer {
                             })
                             .unwrap();
 
-                        if !started {
-                            list.begin_drawing(&DrawBegin {
-                                viewport: Viewport {
-                                    area: FRect2D {
-                                        w: self.width as f32,
-                                        h: self.height as f32,
-                                        ..Default::default()
-                                    },
-                                    scissor: Rect2D {
-                                        w: self.width,
-                                        h: self.height,
-                                        ..Default::default()
-                                    },
+                        list.begin_drawing(&DrawBegin {
+                            viewport: Viewport {
+                                area: FRect2D {
+                                    w: self.width as f32,
+                                    h: self.height as f32,
                                     ..Default::default()
                                 },
-                                pipeline: pso.pipeline,
-                                attachments: &target
-                                    .colors
-                                    .iter()
-                                    .map(|a| a.attachment)
-                                    .collect::<Vec<_>>(),
-                            })
-                            .unwrap();
-                            started = true;
-                        } else {
-                            list.begin_drawing(&DrawBegin {
-                                viewport: Viewport {
-                                    area: FRect2D {
-                                        w: self.width as f32,
-                                        h: self.height as f32,
-                                        ..Default::default()
-                                    },
-                                    scissor: Rect2D {
-                                        w: self.width,
-                                        h: self.height,
-                                        ..Default::default()
-                                    },
+                                scissor: Rect2D {
+                                    w: self.width,
+                                    h: self.height,
                                     ..Default::default()
                                 },
-                                pipeline: pso.pipeline,
-                                attachments: &target
-                                    .colors
-                                    .iter()
-                                    .map(|a| a.attachment)
-                                    .collect::<Vec<_>>(),
-                            })
-                            .unwrap();
-                        }
+                                ..Default::default()
+                            },
+                            pipeline: pso.pipeline,
+                            attachments: &target
+                                .colors
+                                .iter()
+                                .map(|a| a.attachment)
+                                .collect::<Vec<_>>(),
+                        })
+                        .unwrap();
 
                         let vb = mesh.vertex_buffer.expect("Vertex buffer missing");
                         let ib = mesh.index_buffer;
@@ -773,8 +717,6 @@ impl Renderer {
                             })
                         };
                         list.append(draw);
-                    }
-                    if started {
                         list.end_drawing().unwrap();
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure begin/end drawing calls are paired for each mesh draw

## Testing
- `cargo check` *(fails: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687d3b11791c832a90f1fa6b9e612944