### PR TITLE
Fix dynamic text overflow handling

### DIFF
--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -98,6 +98,7 @@ pub fn run(ctx: &mut Context) {
     ));
     renderer.register_text_mesh(SharedDynamic(dynamic.clone()));
     text.register_textures(renderer.resources());
+    const MAX_CHARS: usize = 64;
     let mut input = String::new();
 
     let vert_spv = make_vert();
@@ -118,6 +119,9 @@ pub fn run(ctx: &mut Context) {
                 WindowEvent::ReceivedCharacter(c) => {
                     if !c.is_control() {
                         input.push(c);
+                        if input.chars().count() > MAX_CHARS {
+                            input = input.chars().take(MAX_CHARS).collect();
+                        }
                         changed = true;
                     }
                 }

--- a/src/text/dynamic_text.rs
+++ b/src/text/dynamic_text.rs
@@ -208,14 +208,21 @@ impl DynamicText {
         _scale: f32,
         pos: [f32; 2],
     ) -> Result<(), GPUError> {
-        assert!(text.len() <= self.max_chars);
+        let mut owned;
+        let text = if text.chars().count() > self.max_chars {
+            owned = text.chars().take(self.max_chars).collect::<String>();
+            &owned
+        } else {
+            text
+        };
         if text.is_empty() {
             self.vertex_count = 0;
             self.index_count = 0;
             return Ok(());
         }
-        let mut verts = Vec::with_capacity(text.len() * 4);
-        let mut inds = Vec::with_capacity(text.len() * 6);
+        let char_count = text.chars().count();
+        let mut verts = Vec::with_capacity(char_count * 4);
+        let mut inds = Vec::with_capacity(char_count * 6);
         let mut cursor = pos[0];
         let sx = self.screen_size[0];
         let sy = self.screen_size[1];

--- a/tests/text_renderer.rs
+++ b/tests/text_renderer.rs
@@ -228,8 +228,7 @@ fn dynamic_text_update_empty_string_resets_counts() {
 
 #[test]
 #[serial]
-#[ignore]
-fn dynamic_text_update_over_capacity_panics() {
+fn dynamic_text_update_over_capacity_truncates() {
     let font_bytes = load_system_font();
     let mut registry = FontRegistry::new();
     registry.register_font("default", &font_bytes);
@@ -238,14 +237,10 @@ fn dynamic_text_update_over_capacity_panics() {
     let mut res = ResourceManager::default();
     let info = DynamicTextCreateInfo { max_chars: 2, text: "hi", scale: 16.0, pos: [0.0, 0.0], key: "ovr", screen_size: [320.0, 240.0], color: [1.0; 4], bold: false, italic: false };
     let mut dt = DynamicText::new(&mut ctx, &mut text, &mut res, info).unwrap();
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        dt.update_text(&mut ctx, &mut res, &mut text, "toolong", 16.0, [0.0, 0.0])
-    }));
-    match result {
-        Ok(Err(_)) => {},
-        Err(_) => {},
-        _ => panic!("update should fail"),
-    }
+    dt.update_text(&mut ctx, &mut res, &mut text, "toolong", 16.0, [0.0, 0.0])
+        .unwrap();
+    assert_eq!(dt.vertex_count, 8);
+    assert_eq!(dt.index_count, 12);
     destroy_combined(&mut ctx, &res, "ovr");
     dt.destroy(&mut ctx);
     ctx.destroy();


### PR DESCRIPTION
## Summary
- prevent panic by truncating text in `DynamicText::update_text`
- clamp user input in text2d example
- test overflow behavior in text renderer

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688511a0da18832a8107aa70d802319c