### PR TITLE
Fix canvas output references in examples

### DIFF
--- a/examples/bindless_rendering/bin.rs
+++ b/examples/bindless_rendering/bin.rs
@@ -29,10 +29,11 @@ pub fn run(ctx: &mut Context) {
 
     let vert = simple_vert();
     let frag = simple_frag();
+    let canvas = renderer.canvas(0).unwrap().clone();
     let mut pso = PipelineBuilder::new(ctx, "bindless")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass((renderer.render_pass(), 0))
+        .render_pass(canvas.output("color"))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -11,13 +11,16 @@ use winit::event::{Event, WindowEvent, KeyboardInput, ElementState, VirtualKeyCo
 #[cfg(feature = "gpu_tests")]
 use std::path::Path;
 
-fn build_pbr_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> PSO {
+fn build_pbr_pipeline(
+    ctx: &mut Context,
+    target: koji::canvas::CanvasOutput,
+) -> PSO {
     let vert: &[u32] = include_spirv!("assets/shaders/pbr_spheres.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("assets/shaders/pbr_spheres.frag", frag, glsl);
     PipelineBuilder::new(ctx, "pbr")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass((rp, subpass))
+        .render_pass(target)
         .depth_enable(true)
         .cull_mode(CullMode::Back)
         .build()
@@ -162,7 +165,8 @@ pub fn run(ctx: &mut Context) {
     renderer.set_clear_depth(1.0);
     register_textures(ctx, renderer.resources());
 
-    let mut pso = build_pbr_pipeline(ctx, renderer.render_pass(), 0);
+    let canvas = renderer.canvas(0).unwrap().clone();
+    let mut pso = build_pbr_pipeline(ctx, canvas.output("color"));
 
     let proj =
         Mat4::perspective_rh_gl(45.0_f32.to_radians(), 1920.0 / 1080.0, 0.1, 100.0);

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -37,10 +37,11 @@ pub fn run(ctx: &mut Context) {
         .resources()
         .register_variable("ubo", ctx, 0.7f32);
 
+    let canvas = renderer.canvas(0).unwrap().clone();
     let mut pso = PipelineBuilder::new(ctx, "sample_pso")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass((renderer.render_pass(), 0))
+        .render_pass(canvas.output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
 

--- a/examples/skeletal_animation/bin.rs
+++ b/examples/skeletal_animation/bin.rs
@@ -20,7 +20,8 @@ pub fn run(ctx: &mut Context) {
     let instance = SkeletalInstance::with_player(ctx, animator, player).unwrap();
     renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
-    let mut pso = build_skinning_pipeline(ctx, renderer.render_pass(), 0);
+    let canvas = renderer.canvas(0).unwrap().clone();
+    let mut pso = build_skinning_pipeline(ctx, canvas.output("color"));
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso, bgr);
 

--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -102,10 +102,11 @@ pub fn run(ctx: &mut Context) {
 
     let vert_spv = make_vert();
     let frag_spv = make_frag();
+    let canvas = renderer.canvas(0).unwrap().clone();
     let mut pso = PipelineBuilder::new(ctx, "text_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass((renderer.render_pass(), 0))
+        .render_pass(canvas.output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();

--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -53,10 +53,11 @@ pub fn run(ctx: &mut Context) {
 
     let vert_spv = make_vert();
     let frag_spv = make_frag();
+    let canvas = renderer.canvas(0).unwrap().clone();
     let mut pso = PipelineBuilder::new(ctx, "text3d_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass((renderer.render_pass(), 0))
+        .render_pass(canvas.output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();

--- a/src/material/skin_pipeline.rs
+++ b/src/material/skin_pipeline.rs
@@ -1,13 +1,16 @@
 use inline_spirv::include_spirv;
-use dashi::{*, utils::Handle};
+use dashi::*;
 use crate::material::pipeline_builder::PipelineBuilder;
 
-pub fn build_skinning_pipeline(ctx: &mut Context, rp: Handle<RenderPass>, subpass: u32) -> crate::material::PSO {
+pub fn build_skinning_pipeline(
+    ctx: &mut Context,
+    target: crate::render_graph::GraphOutput,
+) -> crate::material::PSO {
     let vert: &[u32] = include_spirv!("src/renderer/skinning.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("src/renderer/skinning.frag", frag, glsl);
     PipelineBuilder::new(ctx, "skinning_pipeline")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass((rp, subpass))
+        .render_pass(target)
         .build()
 }


### PR DESCRIPTION
## Summary
- use `renderer.canvas(0).unwrap().output("color")` when creating pipelines
- adjust skeletal skin pipeline helper to accept a render graph output
- build examples after renderer creation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688519cdf900832a8fc4753927c4e15e