### PR TITLE
Refactor examples to use RenderGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ demonstrate a simple `geometry -> sky -> compose` pipeline.
 
 Example programs live under the `examples/` directory and can be run with
 `cargo run --example <name>`. These require a Vulkan-capable GPU and a working
-window system. Some of the demos are gated behind the `gpu_tests` feature flag.
+window system. Each example explicitly constructs a `RenderGraph` and a
+`Canvas` before creating pipelines. Some of the demos are gated behind the
+`gpu_tests` feature flag.
 
 Available examples:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,9 @@ These demos showcase different Koji features and can be executed with
 cargo run --example <name>
 ```
 
+Each example builds a small `RenderGraph` and creates a `Canvas` to render into
+before setting up pipelines. This replaces the older `Renderer::new` helper.
+
 Some programs require the `gpu_tests` feature to be enabled. Shaders usually
 pull from `assets/shaders/` and rely on the uniform block provided by
 `assets/shaders/timing.slang` when referencing `KOJI_time`.

--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -5,6 +5,7 @@ use koji::material::*;
 use koji::renderer::*;
 use koji::render_pass::*;
 use koji::canvas::CanvasBuilder;
+use koji::render_graph::RenderGraph;
 use koji::texture_manager;
 use koji::utils::{ResourceManager, ResourceBinding};
 use glam::*;
@@ -14,7 +15,7 @@ use std::path::Path;
 
 fn build_pbr_pipeline(
     ctx: &mut Context,
-    target: koji::canvas::CanvasOutput,
+    target: koji::render_graph::GraphOutput,
 ) -> PSO {
     let vert: &[u32] = include_spirv!("assets/shaders/pbr_spheres.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("assets/shaders/pbr_spheres.frag", frag, glsl);
@@ -174,7 +175,10 @@ pub fn run(ctx: &mut Context) {
         .unwrap();
     renderer.add_canvas(canvas.clone());
 
-    let mut pso = build_pbr_pipeline(ctx, canvas.output("color"));
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+
+    let mut pso = build_pbr_pipeline(ctx, graph.output("color"));
 
     let proj =
         Mat4::perspective_rh_gl(45.0_f32.to_radians(), 1920.0 / 1080.0, 0.1, 100.0);

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -1,11 +1,42 @@
 use dashi::*;
 use inline_spirv::include_spirv;
+use koji::canvas::CanvasBuilder;
 use koji::material::PipelineBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 
 pub fn run(ctx: &mut Context) {
-    let mut renderer = Renderer::new(640, 480, "sample", ctx).unwrap();
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .viewport(Viewport {
+            area: FRect2D {
+                w: 640.0,
+                h: 480.0,
+                ..Default::default()
+            },
+            scissor: Rect2D {
+                w: 640,
+                h: 480,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(640, 480, ctx, builder).unwrap();
     renderer.set_clear_depth(1.0);
+
+    let canvas = CanvasBuilder::new()
+        .extent([640, 480])
+        .color_attachment("color", Format::RGBA8)
+        .build(ctx)
+        .unwrap();
+    renderer.add_canvas(canvas.clone());
+
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
 
     let vert: &[u32] = include_spirv!("assets/shaders/sample.vert", vert);
     let frag: &[u32] = include_spirv!("assets/shaders/sample.frag", frag);
@@ -37,11 +68,10 @@ pub fn run(ctx: &mut Context) {
         .resources()
         .register_variable("ubo", ctx, 0.7f32);
 
-    let canvas = renderer.canvas(0).unwrap().clone();
     let mut pso = PipelineBuilder::new(ctx, "sample_pso")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(canvas.output("color"))
+        .render_pass(graph.output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
 

--- a/examples/skeletal_animation/bin.rs
+++ b/examples/skeletal_animation/bin.rs
@@ -1,13 +1,36 @@
 use dashi::*;
 use koji::animation::clip::AnimationPlayer;
 use koji::animation::Animator;
+use koji::canvas::CanvasBuilder;
 use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 
 #[cfg(feature = "gpu_tests")]
 pub fn run(ctx: &mut Context) {
-    let mut renderer = Renderer::new(320, 240, "anim", ctx).unwrap();
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .viewport(Viewport {
+            area: FRect2D { w: 320.0, h: 240.0, ..Default::default() },
+            scissor: Rect2D { w: 320, h: 240, ..Default::default() },
+            ..Default::default()
+        })
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, ctx, builder).unwrap();
+
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(ctx)
+        .unwrap();
+    renderer.add_canvas(canvas.clone());
+
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh {
@@ -20,8 +43,7 @@ pub fn run(ctx: &mut Context) {
     let instance = SkeletalInstance::with_player(ctx, animator, player).unwrap();
     renderer.register_skeletal_mesh(mesh, vec![instance], "skin".into());
 
-    let canvas = renderer.canvas(0).unwrap().clone();
-    let mut pso = build_skinning_pipeline(ctx, canvas.output("color"));
+    let mut pso = build_skinning_pipeline(ctx, graph.output("color"));
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_skeletal_pso(pso, bgr);
 

--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -1,7 +1,10 @@
 use dashi::*;
 use dashi::utils::Handle;
 use inline_spirv::include_spirv;
+use koji::canvas::CanvasBuilder;
 use koji::material::pipeline_builder::PipelineBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 use koji::text::*;
 use std::cell::RefCell;
@@ -57,7 +60,27 @@ impl TextRenderable for SharedDynamic {
 
 #[cfg(feature = "gpu_tests")]
 pub fn run(ctx: &mut Context) {
-    let mut renderer = Renderer::new(320, 240, "text", ctx).expect("renderer");
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .viewport(Viewport {
+            area: FRect2D { w: 320.0, h: 240.0, ..Default::default() },
+            scissor: Rect2D { w: 320, h: 240, ..Default::default() },
+            ..Default::default()
+        })
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, ctx, builder).expect("renderer");
+
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(ctx)
+        .unwrap();
+    renderer.add_canvas(canvas.clone());
+
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
 
     let font_bytes = load_system_font().unwrap_or_else(|e| {
         eprintln!("{}", e);
@@ -110,11 +133,10 @@ pub fn run(ctx: &mut Context) {
 
     let vert_spv = make_vert();
     let frag_spv = make_frag();
-    let canvas = renderer.canvas(0).unwrap().clone();
     let mut pso = PipelineBuilder::new(ctx, "text_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass(canvas.output("color"))
+        .render_pass(graph.output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();

--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -1,6 +1,9 @@
 use dashi::*;
 use inline_spirv::include_spirv;
+use koji::canvas::CanvasBuilder;
 use koji::material::pipeline_builder::PipelineBuilder;
+use koji::render_graph::RenderGraph;
+use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 use koji::text::*;
 use glam::*;
@@ -37,8 +40,28 @@ fn make_frag() -> Vec<u32> {
 
 #[cfg(feature = "gpu_tests")]
 pub fn run(ctx: &mut Context) {
-    let mut renderer = Renderer::new(320, 240, "text3d", ctx).expect("renderer");
+    let builder = RenderPassBuilder::new()
+        .debug_name("MainPass")
+        .viewport(Viewport {
+            area: FRect2D { w: 320.0, h: 240.0, ..Default::default() },
+            scissor: Rect2D { w: 320, h: 240, ..Default::default() },
+            ..Default::default()
+        })
+        .color_attachment("color", Format::RGBA8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let mut renderer = Renderer::with_render_pass(320, 240, ctx, builder).expect("renderer");
     renderer.set_clear_depth(1.0);
+
+    let canvas = CanvasBuilder::new()
+        .extent([320, 240])
+        .color_attachment("color", Format::RGBA8)
+        .build(ctx)
+        .unwrap();
+    renderer.add_canvas(canvas.clone());
+
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
 
     let font_bytes = load_system_font().unwrap_or_else(|e| {
         eprintln!("{}", e);
@@ -61,11 +84,10 @@ pub fn run(ctx: &mut Context) {
 
     let vert_spv = make_vert();
     let frag_spv = make_frag();
-    let canvas = renderer.canvas(0).unwrap().clone();
     let mut pso = PipelineBuilder::new(ctx, "text3d_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass(canvas.output("color"))
+        .render_pass(graph.output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();


### PR DESCRIPTION
## Summary
- update examples to create `Canvas` objects and build a `RenderGraph`
- adjust example README and root README to document the new initialization

## Testing
- `cargo test --no-run` *(fails: missing system libraries and long build times)*
- `cargo run --example sample` *(fails: `libXcursor` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68864c1e6034832a835fb093ba25e0d2