### PR TITLE
Fix depth-stencil aspect mask

### DIFF
--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -247,7 +247,7 @@ impl RenderPassBuilder {
                 layer: 0,
                 mip_level: 0,
                 aspect: if att.format == Format::D24S8 {
-                    AspectMask::Depth
+                    AspectMask::Depth | AspectMask::Stencil
                 } else {
                     Default::default()
                 }


### PR DESCRIPTION
## Summary
- use both depth and stencil bits when creating D24S8 views

## Testing
- `cargo test --lib` *(fails: took too long / was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688a7571be3c832aa2d28800ca5f7a49