### PR TITLE
Use viewport helpers when drawing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 [[package]]
 name = "dashi"
 version = "0.1.0"
-source = "git+https://github.com/JordanHendl/dashi#50cd4813f537f4d0cc1cc61b073349b93806e801"
+source = "git+https://github.com/JordanHendl/dashi#6c2ac359f1072f8fd2d998d422777ff0f729fe7b"
 dependencies = [
  "ash",
  "ash-window",

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -590,11 +590,23 @@ impl Renderer {
                                 true,
                             );
                             list.begin_drawing(&draw_begin).unwrap();
+                            list.set_viewport(draw_begin.viewport);
+                            list.set_scissor(draw_begin.viewport.scissor);
                             #[cfg(test)]
                             draw_log::log("begin_static");
                             started = true;
                         } else {
-                            list.bind_pipeline(pso.pipeline).unwrap();
+                            let draw_begin = Self::prepare_draw_begin(
+                                width,
+                                height,
+                                &target,
+                                pso.pipeline,
+                                &mut attachments,
+                                true,
+                            );
+                            list.begin_drawing(&draw_begin).unwrap();
+                            list.set_viewport(draw_begin.viewport);
+                            list.set_scissor(draw_begin.viewport.scissor);
                             #[cfg(test)]
                             draw_log::log("bind_static");
                         }
@@ -651,6 +663,8 @@ impl Renderer {
                             false,
                         );
                         list.begin_drawing(&draw_begin).unwrap();
+                        list.set_viewport(draw_begin.viewport);
+                        list.set_scissor(draw_begin.viewport.scissor);
 
                         for mesh in &self.text_drawables {
                             let vb = mesh.vertex_buffer();
@@ -727,6 +741,8 @@ impl Renderer {
                                 false,
                             );
                             list.begin_drawing(&draw_begin).unwrap();
+                            list.set_viewport(draw_begin.viewport);
+                            list.set_scissor(draw_begin.viewport.scissor);
                             #[cfg(test)]
                             draw_log::log("begin_skeletal");
                             started = true;


### PR DESCRIPTION
## Summary
- update Cargo lock to dashi commit `6c2ac359`
- set render area with `set_viewport` and `set_scissor` when drawing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688cef34f580832ab1e7e36588ae6bfe