### PR TITLE
Refactor tests to use updated Renderer constructors

### DIFF
--- a/tests/bindless_lighting.rs
+++ b/tests/bindless_lighting.rs
@@ -2,7 +2,6 @@ use koji::material::*;
 use koji::renderer::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 use inline_spirv::inline_spirv;
 
@@ -40,13 +39,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).unwrap();
 
     let mut pso = PipelineBuilder::new(&mut ctx, "lights")
         .vertex_shader(&vert())

--- a/tests/bindless_rendering.rs
+++ b/tests/bindless_rendering.rs
@@ -2,7 +2,6 @@ use koji::material::*;
 use koji::renderer::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 
 use inline_spirv::inline_spirv;
@@ -40,13 +39,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).unwrap();
 
     let vert = simple_vert();
     let frag = simple_frag();

--- a/tests/compute_pipeline.rs
+++ b/tests/compute_pipeline.rs
@@ -1,7 +1,6 @@
 use koji::renderer::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use koji::material::ComputePipelineBuilder;
 use dashi::*;
 use inline_spirv::inline_spirv;
@@ -36,13 +35,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(64, 64, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(64, 64, &mut ctx, graph).unwrap();
 
     let initial: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
     let buffer = ctx

--- a/tests/custom_pass.rs
+++ b/tests/custom_pass.rs
@@ -37,12 +37,11 @@ subpasses:
         .build(&mut ctx)
         .unwrap();
     let mut graph = RenderGraph::new();
+    let config: YamlRenderPass = serde_yaml::from_str(yaml).unwrap();
+    graph.add_node(RenderPassBuilder::from_yaml(config).into());
     graph.add_canvas(&canvas);
 
-    let config: YamlRenderPass = serde_yaml::from_str(yaml).unwrap();
-    let builder = RenderPassBuilder::from_yaml(config);
-    let mut renderer = Renderer::with_render_pass(640, 480, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(640, 480, &mut ctx, graph).unwrap();
 
     let vert = include_spirv!("assets/shaders/test_triangle.vert", vert);
     let frag = include_spirv!("assets/shaders/test_triangle.frag", frag);

--- a/tests/pbr_renderer.rs
+++ b/tests/pbr_renderer.rs
@@ -2,7 +2,6 @@ use koji::material::*;
 use koji::renderer::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 
 use inline_spirv::include_spirv;
@@ -54,13 +53,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).expect("renderer");
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).expect("renderer");
 
     let vert: &[u32] = include_spirv!("assets/shaders/pbr.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("assets/shaders/pbr.frag", frag, glsl);

--- a/tests/pbr_texture_loading.rs
+++ b/tests/pbr_texture_loading.rs
@@ -3,7 +3,6 @@ use koji::renderer::*;
 use koji::texture_manager as texman;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 use dashi::gpu;
 use dashi::utils::Handle;
@@ -65,13 +64,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(64, 64, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(64, 64, &mut ctx, graph).unwrap();
 
     let vert: &[u32] = include_spirv!("assets/shaders/pbr.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("assets/shaders/pbr.frag", frag, glsl);

--- a/tests/pipeline_group.rs
+++ b/tests/pipeline_group.rs
@@ -1,6 +1,6 @@
 use koji::renderer::{Renderer, test_hooks, StaticMesh, Vertex, SkeletalMesh, SkeletalVertex, SkeletalInstance};
 use koji::material::pipeline_builder::PipelineBuilder;
-use koji::render_pass::RenderPassBuilder;
+use koji::canvas::CanvasBuilder;
 use koji::animation::{Skeleton, Bone, Animator};
 use dashi::gpu::{Context, ContextInfo};
 use dashi::{Format};
@@ -37,11 +37,12 @@ fn simple_skel_vertex(p: [f32;3]) -> SkeletalVertex {
 #[ignore]
 fn static_pipeline_groups_once() {
     let mut ctx = make_ctx();
-    let builder = RenderPassBuilder::new()
-        .debug_name("test")
+    let canvas = CanvasBuilder::new()
+        .extent([64, 64])
         .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-    let mut renderer = Renderer::with_render_pass(64, 64, &mut ctx, builder).unwrap();
+        .build(&mut ctx)
+        .unwrap();
+    let mut renderer = Renderer::with_canvas(64, 64, &mut ctx, canvas).unwrap();
 
     let mut pso = PipelineBuilder::new(&mut ctx, "p")
         .vertex_shader(&simple_vert())
@@ -82,11 +83,12 @@ fn static_pipeline_groups_once() {
 #[ignore]
 fn skeletal_pipeline_groups_once() {
     let mut ctx = make_ctx();
-    let builder = RenderPassBuilder::new()
-        .debug_name("test")
+    let canvas = CanvasBuilder::new()
+        .extent([64, 64])
         .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-    let mut renderer = Renderer::with_render_pass(64, 64, &mut ctx, builder).unwrap();
+        .build(&mut ctx)
+        .unwrap();
+    let mut renderer = Renderer::with_canvas(64, 64, &mut ctx, canvas).unwrap();
 
     let vert: &[u32] = include_spirv!("src/renderer/skinning.vert", vert, glsl);
     let frag: &[u32] = include_spirv!("src/renderer/skinning.frag", frag, glsl);

--- a/tests/sample-triangle.rs
+++ b/tests/sample-triangle.rs
@@ -2,7 +2,6 @@ use koji::*;
 use koji::renderer::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 use inline_spirv::include_spirv;
 use serial_test::serial;
@@ -93,13 +92,7 @@ fn render_triangle_and_cube() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(640, 480, &mut ctx, builder).expect("Error making Renderer");
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(640, 480, &mut ctx, graph).expect("Error making Renderer");
 
     // Shaders
     let vert_spv = make_shader_vert();

--- a/tests/skeletal_animation.rs
+++ b/tests/skeletal_animation.rs
@@ -5,7 +5,6 @@ use koji::animation::Animator;
 use koji::animation::clip::AnimationPlayer;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use inline_spirv::include_spirv;
 use dashi::*;
 
@@ -24,13 +23,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).unwrap();
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh { MeshData::Skeletal(m) => m.clone(), _ => panic!("expected skel") };

--- a/tests/skeletal_renderer.rs
+++ b/tests/skeletal_renderer.rs
@@ -3,7 +3,6 @@ use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use glam::Mat4;
 use koji::animation::Animator;
 use inline_spirv::include_spirv;
@@ -25,13 +24,7 @@ pub fn run_simple_skeleton() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).unwrap();
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh {
@@ -73,13 +66,7 @@ pub fn run_update_bones_twice() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).unwrap();
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh {

--- a/tests/skinned_mesh_render.rs
+++ b/tests/skinned_mesh_render.rs
@@ -3,7 +3,6 @@ use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use inline_spirv::include_spirv;
 use glam::Mat4;
 use koji::animation::Animator;
@@ -24,13 +23,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).unwrap();
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh { MeshData::Skeletal(m) => m.clone(), _ => panic!("expected skel") };

--- a/tests/static_movement.rs
+++ b/tests/static_movement.rs
@@ -2,7 +2,6 @@ use koji::material::*;
 use koji::renderer::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 
 use inline_spirv::inline_spirv;
@@ -43,13 +42,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).unwrap();
 
     let mut pso = PipelineBuilder::new(&mut ctx,"move_pso")
         .vertex_shader(&vert())

--- a/tests/text2d.rs
+++ b/tests/text2d.rs
@@ -5,7 +5,6 @@ use koji::renderer::*;
 use koji::text::*;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::*;
 use inline_spirv::include_spirv;
 
@@ -72,13 +71,7 @@ pub fn run() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, &mut ctx, builder).expect("renderer");
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(320, 240, &mut ctx, graph).expect("renderer");
 
     let font_bytes = load_system_font().unwrap_or_else(|e| {
         eprintln!("{}", e);

--- a/tests/time_stats.rs
+++ b/tests/time_stats.rs
@@ -4,7 +4,6 @@ use koji::renderer::Renderer;
 use koji::utils::ResourceBinding;
 use koji::canvas::CanvasBuilder;
 use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use dashi::gpu;
 use dashi::Format;
 use serial_test::serial;
@@ -44,13 +43,7 @@ fn renderer_updates_time_buffer() {
     let mut graph = RenderGraph::new();
     graph.add_canvas(&canvas);
 
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(64, 64, &mut ctx, builder).unwrap();
-    renderer.add_canvas(canvas);
+    let mut renderer = Renderer::with_graph(64, 64, &mut ctx, graph).unwrap();
 
     renderer.present_frame().unwrap();
     std::thread::sleep(Duration::from_millis(5));


### PR DESCRIPTION
## Summary
- Replace deprecated `with_render_pass` usage in tests with `with_graph` or `with_canvas`
- Inline canvas creation in pipeline group tests and remove redundant `add_canvas` calls
- Integrate custom render pass into test render graph

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6896d89c7130832aacd954296f4c92b4