### PR TITLE
Refactor renderer initialization API

### DIFF
--- a/examples/bindless_rendering/bin.rs
+++ b/examples/bindless_rendering/bin.rs
@@ -1,8 +1,6 @@
 use inline_spirv::inline_spirv;
 use koji::canvas::CanvasBuilder;
 use koji::material::*;
-use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 use dashi::*;
 
@@ -28,42 +26,20 @@ fn simple_frag() -> Vec<u32> {
 
 #[cfg(feature = "gpu_tests")]
 pub fn run(ctx: &mut Context) {
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .viewport(Viewport {
-            area: FRect2D {
-                w: 320.0,
-                h: 240.0,
-                ..Default::default()
-            },
-            scissor: Rect2D {
-                w: 320,
-                h: 240,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, ctx, builder).unwrap();
-
     let canvas = CanvasBuilder::new()
         .extent([320, 240])
         .color_attachment("color", Format::RGBA8)
         .build(ctx)
         .unwrap();
-    renderer.add_canvas(canvas.clone());
 
-    let mut graph = RenderGraph::new();
-    graph.add_canvas(&canvas);
+    let mut renderer = Renderer::with_canvas(320, 240, ctx, canvas).unwrap();
 
     let vert = simple_vert();
     let frag = simple_frag();
     let mut pso = PipelineBuilder::new(ctx, "bindless")
         .vertex_shader(&vert)
         .fragment_shader(&frag)
-        .render_pass(graph.output("color"))
+        .render_pass(renderer.graph().output("color"))
         .build();
     let bgr = pso.create_bind_groups(&renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bgr);

--- a/examples/compute_example/bin.rs
+++ b/examples/compute_example/bin.rs
@@ -1,9 +1,6 @@
 use dashi::*;
 use inline_spirv::inline_spirv;
-use koji::canvas::CanvasBuilder;
 use koji::material::ComputePipelineBuilder;
-use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 
 fn compute_spirv() -> Vec<u32> {
@@ -22,27 +19,7 @@ fn compute_spirv() -> Vec<u32> {
 
 #[cfg(feature = "gpu_tests")]
 pub fn run(ctx: &mut Context) {
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .viewport(Viewport {
-            area: FRect2D { w: 64.0, h: 64.0, ..Default::default() },
-            scissor: Rect2D { w: 64, h: 64, ..Default::default() },
-            ..Default::default()
-        })
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(64, 64, ctx, builder).unwrap();
-
-    let canvas = CanvasBuilder::new()
-        .extent([64, 64])
-        .color_attachment("color", Format::RGBA8)
-        .build(ctx)
-        .unwrap();
-    renderer.add_canvas(canvas.clone());
-
-    let mut graph = RenderGraph::new();
-    graph.add_canvas(&canvas);
+    let mut renderer = Renderer::new(64, 64, "", ctx).unwrap();
 
     let input: [f32; 4] = [1.0, 2.0, 3.0, 4.0];
     let buffer = ctx

--- a/examples/pbr_spheres/bin.rs
+++ b/examples/pbr_spheres/bin.rs
@@ -3,9 +3,7 @@ use dashi::*;
 use inline_spirv::include_spirv;
 use koji::material::*;
 use koji::renderer::*;
-use koji::render_pass::*;
 use koji::canvas::CanvasBuilder;
-use koji::render_graph::RenderGraph;
 use koji::texture_manager;
 use koji::utils::{ResourceManager, ResourceBinding};
 use glam::*;
@@ -144,41 +142,18 @@ struct CameraUniform {
 }
 
 pub fn run(ctx: &mut Context) {
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .viewport(Viewport {
-            area: FRect2D {
-                w: 1920.0,
-                h: 1080.0,
-                ..Default::default()
-            },
-            scissor: Rect2D {
-                w: 1920,
-                h: 1080,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .color_attachment("color", Format::RGBA8)
-        .depth_attachment("depth", Format::D24S8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(1920, 1080, ctx, builder).unwrap();
-    renderer.set_clear_depth(1.0);
-    register_textures(ctx, renderer.resources());
-
     let canvas = CanvasBuilder::new()
         .extent([1920, 1080])
         .color_attachment("color", Format::RGBA8)
         .depth_attachment("depth", Format::D24S8)
         .build(ctx)
         .unwrap();
-    renderer.add_canvas(canvas.clone());
 
-    let mut graph = RenderGraph::new();
-    graph.add_canvas(&canvas);
+    let mut renderer = Renderer::with_canvas(1920, 1080, ctx, canvas).unwrap();
+    renderer.set_clear_depth(1.0);
+    register_textures(ctx, renderer.resources());
 
-    let mut pso = build_pbr_pipeline(ctx, graph.output("color"));
+    let mut pso = build_pbr_pipeline(ctx, renderer.graph().output("color"));
 
     let proj =
         Mat4::perspective_rh_gl(45.0_f32.to_radians(), 1920.0 / 1080.0, 0.1, 100.0);

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -2,41 +2,17 @@ use dashi::*;
 use inline_spirv::include_spirv;
 use koji::canvas::CanvasBuilder;
 use koji::material::PipelineBuilder;
-use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 
 pub fn run(ctx: &mut Context) {
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .viewport(Viewport {
-            area: FRect2D {
-                w: 640.0,
-                h: 480.0,
-                ..Default::default()
-            },
-            scissor: Rect2D {
-                w: 640,
-                h: 480,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(640, 480, ctx, builder).unwrap();
-    renderer.set_clear_depth(1.0);
-
     let canvas = CanvasBuilder::new()
         .extent([640, 480])
         .color_attachment("color", Format::RGBA8)
         .build(ctx)
         .unwrap();
-    renderer.add_canvas(canvas.clone());
 
-    let mut graph = RenderGraph::new();
-    graph.add_canvas(&canvas);
+    let mut renderer = Renderer::with_canvas(640, 480, ctx, canvas).unwrap();
+    renderer.set_clear_depth(1.0);
 
     let vert: &[u32] = include_spirv!("assets/shaders/sample.vert", vert);
     let frag: &[u32] = include_spirv!("assets/shaders/sample.frag", frag);
@@ -71,7 +47,7 @@ pub fn run(ctx: &mut Context) {
     let mut pso = PipelineBuilder::new(ctx, "sample_pso")
         .vertex_shader(vert)
         .fragment_shader(frag)
-        .render_pass(graph.output("color"))
+        .render_pass(renderer.graph().output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
 

--- a/examples/sample/bin.rs
+++ b/examples/sample/bin.rs
@@ -48,12 +48,9 @@ pub fn run(ctx: &mut Context) {
         .vertex_shader(vert)
         .fragment_shader(frag)
         .render_pass(renderer.graph().output("color"))
-        .build_with_resources(renderer.resources())
-        .unwrap();
+        .build();
 
-    let bind_groups = pso
-        .create_bind_groups(renderer.resources())
-        .unwrap();
+    let bind_groups = pso.create_bind_groups(renderer.resources()).unwrap();
     renderer.register_pipeline_for_pass("main", pso, bind_groups);
 
     let mesh = StaticMesh {

--- a/examples/skeletal_animation/bin.rs
+++ b/examples/skeletal_animation/bin.rs
@@ -4,33 +4,17 @@ use koji::animation::Animator;
 use koji::canvas::CanvasBuilder;
 use koji::gltf::{load_scene, MeshData};
 use koji::material::*;
-use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 
 #[cfg(feature = "gpu_tests")]
 pub fn run(ctx: &mut Context) {
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .viewport(Viewport {
-            area: FRect2D { w: 320.0, h: 240.0, ..Default::default() },
-            scissor: Rect2D { w: 320, h: 240, ..Default::default() },
-            ..Default::default()
-        })
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, ctx, builder).unwrap();
-
     let canvas = CanvasBuilder::new()
         .extent([320, 240])
         .color_attachment("color", Format::RGBA8)
         .build(ctx)
         .unwrap();
-    renderer.add_canvas(canvas.clone());
 
-    let mut graph = RenderGraph::new();
-    graph.add_canvas(&canvas);
+    let mut renderer = Renderer::with_canvas(320, 240, ctx, canvas).unwrap();
 
     let scene = load_scene("assets/data/simple_skin.gltf").expect("load");
     let mesh = match &scene.meshes[0].mesh {

--- a/examples/text2d/bin.rs
+++ b/examples/text2d/bin.rs
@@ -121,8 +121,7 @@ pub fn run(ctx: &mut Context) {
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
         .render_pass(renderer.graph().output("color"))
-        .build_with_resources(renderer.resources())
-        .unwrap();
+        .build();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Text, pso, bgr);
 

--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -2,8 +2,6 @@ use dashi::*;
 use inline_spirv::include_spirv;
 use koji::canvas::CanvasBuilder;
 use koji::material::pipeline_builder::PipelineBuilder;
-use koji::render_graph::RenderGraph;
-use koji::render_pass::RenderPassBuilder;
 use koji::renderer::*;
 use koji::text::*;
 use glam::*;
@@ -40,28 +38,14 @@ fn make_frag() -> Vec<u32> {
 
 #[cfg(feature = "gpu_tests")]
 pub fn run(ctx: &mut Context) {
-    let builder = RenderPassBuilder::new()
-        .debug_name("MainPass")
-        .viewport(Viewport {
-            area: FRect2D { w: 320.0, h: 240.0, ..Default::default() },
-            scissor: Rect2D { w: 320, h: 240, ..Default::default() },
-            ..Default::default()
-        })
-        .color_attachment("color", Format::RGBA8)
-        .subpass("main", ["color"], &[] as &[&str]);
-
-    let mut renderer = Renderer::with_render_pass(320, 240, ctx, builder).expect("renderer");
-    renderer.set_clear_depth(1.0);
-
     let canvas = CanvasBuilder::new()
         .extent([320, 240])
         .color_attachment("color", Format::RGBA8)
         .build(ctx)
         .unwrap();
-    renderer.add_canvas(canvas.clone());
 
-    let mut graph = RenderGraph::new();
-    graph.add_canvas(&canvas);
+    let mut renderer = Renderer::with_canvas(320, 240, ctx, canvas).expect("renderer");
+    renderer.set_clear_depth(1.0);
 
     let font_bytes = load_system_font().unwrap_or_else(|e| {
         eprintln!("{}", e);
@@ -87,7 +71,7 @@ pub fn run(ctx: &mut Context) {
     let mut pso = PipelineBuilder::new(ctx, "text3d_pso")
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
-        .render_pass(graph.output("color"))
+        .render_pass(renderer.graph().output("color"))
         .build_with_resources(renderer.resources())
         .unwrap();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();

--- a/examples/text3d/bin.rs
+++ b/examples/text3d/bin.rs
@@ -72,8 +72,7 @@ pub fn run(ctx: &mut Context) {
         .vertex_shader(&vert_spv)
         .fragment_shader(&frag_spv)
         .render_pass(renderer.graph().output("color"))
-        .build_with_resources(renderer.resources())
-        .unwrap();
+        .build();
     let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
     renderer.register_pso(RenderStage::Text, pso, bgr);
 


### PR DESCRIPTION
## Summary
- remove `with_render_pass` and `with_render_pass_yaml`
- inline render-pass setup inside `with_graph`
- update examples to construct renderers with `with_canvas`

## Testing
- `cargo test` *(failed: build process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_6897fab11e6c832abd1b5767fd296d63