### PR TITLE
Add frame diff utility and headless comparison helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ cargo build
 cargo test
 ```
 
+## Headless Rendering and Frame Comparison
+
+`Renderer` can run without a display, making it suitable for image-based
+testing. Capture the contents of a color attachment with
+`Renderer::read_color_target("color")` and compare it against a reference
+frame using `utils::diff_rgba8` or the convenience method
+`Renderer::frame_difference`:
+
+```rust
+let diff = renderer.frame_difference(&reference_frame);
+assert!(diff < 0.01);
+```
+
 ## Frame Timing
 
 Shaders that reference the `KOJI_time` uniform automatically receive a timing

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -8,7 +8,7 @@ use crate::material::{BindlessLights, LightDesc, PSOBindGroupResources, CPSO, PS
 use crate::render_graph::{RenderGraph, RenderPassNode, ResourceDesc};
 use crate::render_pass::*;
 use crate::text::{FontRegistry, TextRenderable};
-use crate::utils::{ResourceBinding, ResourceManager};
+use crate::utils::{diff_rgba8, ResourceBinding, ResourceManager};
 use dashi::utils::*;
 use dashi::*;
 use glam::Mat4;
@@ -951,6 +951,18 @@ impl Renderer {
         ctx.destroy_fence(fence);
 
         data
+    }
+
+    /// Compute the mean absolute per-channel difference between the current
+    /// `"color"` attachment and a reference frame.
+    ///
+    /// The reference slice must contain `width * height * 4` RGBA8 bytes. This
+    /// is primarily intended for headless testing where rendered frames are
+    /// compared against known-good outputs. The returned value is normalized to
+    /// `0.0..=1.0`.
+    pub fn frame_difference(&mut self, reference: &[u8]) -> f32 {
+        let current = self.read_color_target("color");
+        diff_rgba8(&current, reference)
     }
 }
 

--- a/src/utils/frame_diff.rs
+++ b/src/utils/frame_diff.rs
@@ -1,0 +1,37 @@
+/// Utilities for comparing image frames.
+///
+/// The primary entry point is [`diff_rgba8`], which computes the mean absolute
+/// difference between two RGBA8 images.
+
+/// Compute the mean absolute per-channel difference between two RGBA8 images.
+///
+/// The slices must contain `width * height * 4` bytes. The result is normalized
+/// to the range `0.0..=1.0`, where `0.0` indicates identical images.
+pub fn diff_rgba8(a: &[u8], b: &[u8]) -> f32 {
+    assert_eq!(a.len(), b.len());
+    assert_eq!(a.len() % 4, 0);
+    let sum: u64 = a
+        .iter()
+        .zip(b)
+        .map(|(x, y)| (*x as i32 - *y as i32).abs() as u64)
+        .sum();
+    sum as f32 / (a.len() as f32 * 255.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::diff_rgba8;
+
+    #[test]
+    fn identical_buffers_have_zero_difference() {
+        let img = vec![10u8; 8];
+        assert_eq!(diff_rgba8(&img, &img), 0.0);
+    }
+
+    #[test]
+    fn max_difference_is_one() {
+        let a = vec![0u8; 4];
+        let b = vec![255u8; 4];
+        assert!((diff_rgba8(&a, &b) - 1.0).abs() < f32::EPSILON);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -33,8 +33,10 @@ impl From<BufferUsage> for DashiBufferUsage {
 
 pub mod allocator;
 pub mod resource_list;
+pub mod frame_diff;
 pub use allocator::*;
 pub use resource_list::*;
+pub use frame_diff::diff_rgba8;
 
 pub struct TextureInfo {
     pub image: Handle<Image>,


### PR DESCRIPTION
## Summary
- add `diff_rgba8` helper for computing mean per-channel image differences
- expose frame-diff utilities via `Renderer::frame_difference`
- document headless rendering comparison workflow

## Testing
- `rustc --test src/utils/frame_diff.rs`
- `cargo test` *(fails: building `shaderc-sys` did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_6898212abf9c832a89e86487a382a45f