### PR TITLE
Use depth-stencil aspect mask for D24S8 attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
 name = "koji"
 version = "0.1.0"
 dependencies = [
+ "ash",
  "bytemuck",
  "dashi",
  "glam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ once_cell = "1.21.3"
 
 [dev-dependencies]
 serial_test = "2.0"
+ash = "0.37"
 
 [features]
 # Enable integration tests that require a Vulkan-capable GPU

--- a/src/render_pass.rs
+++ b/src/render_pass.rs
@@ -247,7 +247,7 @@ impl RenderPassBuilder {
                 layer: 0,
                 mip_level: 0,
                 aspect: if att.format == Format::D24S8 {
-                    AspectMask::Depth
+                    AspectMask::DepthStencil
                 } else {
                     Default::default()
                 }

--- a/tests/depth_stencil_transition.rs
+++ b/tests/depth_stencil_transition.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "gpu_tests")]
+
+use serial_test::serial;
+use koji::render_pass::RenderPassBuilder;
+use dashi::gpu::{Context, ContextInfo};
+use dashi::Format;
+use ash::vk;
+
+fn setup_ctx() -> Context {
+    Context::headless(&ContextInfo::default()).unwrap()
+}
+
+#[test]
+#[serial]
+fn transition_depth_stencil_image() {
+    let mut ctx = setup_ctx();
+
+    let builder = RenderPassBuilder::new()
+        .debug_name("DepthStencil")
+        .extent([4, 4])
+        .color_attachment("color", Format::RGBA8)
+        .depth_attachment("depth", Format::D24S8)
+        .subpass("main", ["color"], &[] as &[&str]);
+
+    let (_rp, targets, _all) = builder.build_with_images(&mut ctx).unwrap();
+    let depth_view = targets[0].depth.as_ref().unwrap().attachment.img;
+
+    let mut cmd = ctx.begin_command_list(&Default::default()).unwrap();
+    ctx.transition_image(cmd.cmd_buf, depth_view, vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    ctx.transition_image(cmd.cmd_buf, depth_view, vk::ImageLayout::GENERAL);
+    let fence = ctx.submit(&mut cmd, &Default::default()).unwrap();
+    ctx.wait(fence).unwrap();
+
+    ctx.destroy();
+}
+


### PR DESCRIPTION
## Summary
- ensure D24S8 image views use a depth-stencil aspect mask
- add regression test covering depth-stencil image transitions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b4d890e0832ab67137b3cc44c816