### PR TITLE
Add built-in camera uniform support

### DIFF
--- a/assets/shaders/camera.slang
+++ b/assets/shaders/camera.slang
@@ -1,0 +1,8 @@
+#define KOJI_MAX_CAMERAS 4
+struct Camera {
+    mat4 view_proj;
+    vec4 cam_pos;
+};
+layout(set = 0, binding = 4) uniform CameraBuffer {
+    Camera cameras[KOJI_MAX_CAMERAS];
+} KOJI_cameras;

--- a/assets/shaders/pbr_spheres.frag
+++ b/assets/shaders/pbr_spheres.frag
@@ -1,4 +1,5 @@
 #version 450
+#include "camera.slang"
 
 layout(location = 0) in vec3 vWorldPos;
 layout(location = 1) in vec3 vNormal;
@@ -8,11 +9,6 @@ layout(set = 0, binding = 0) uniform sampler2D albedo_map;
 layout(set = 0, binding = 1) uniform sampler2D normal_map;
 layout(set = 0, binding = 2) uniform sampler2D metallic_map;
 layout(set = 0, binding = 3) uniform sampler2D roughness_map;
-
-layout(set = 0, binding = 4) uniform CameraBlock {
-    mat4 view_proj;
-    vec3 cam_pos;
-} Camera;
 
 struct Light {
     vec3 position;
@@ -57,7 +53,7 @@ void main() {
 
     vec3 normal = texture(normal_map, vUV).xyz;
     vec3 N = normalize(normal);
-    vec3 V = normalize(Camera.cam_pos - vWorldPos);
+    vec3 V = normalize(KOJI_cameras[0].cam_pos.xyz - vWorldPos);
     vec3 L = normalize(SceneLight.light.position - vWorldPos);
     vec3 H = normalize(V + L);
 

--- a/assets/shaders/pbr_spheres.vert
+++ b/assets/shaders/pbr_spheres.vert
@@ -1,8 +1,5 @@
 #version 450
-layout(set = 0, binding = 4) uniform CameraBlock {
-    mat4 view_proj;
-    vec3 cam_pos;
-} Camera;
+#include "camera.slang"
 
 layout(location = 0) in vec3 inPos;
 layout(location = 1) in vec3 inNormal;
@@ -20,5 +17,5 @@ void main() {
     vWorldPos = world.xyz;
     vNormal = mat3(model) * inNormal;
     vUV = inUV;
-    gl_Position = Camera.view_proj * world;
+    gl_Position = KOJI_cameras[0].view_proj * world;
 }

--- a/assets/shaders/shadows.vert
+++ b/assets/shaders/shadows.vert
@@ -1,7 +1,5 @@
 #version 450
-layout(set = 0, binding = 0) uniform Camera {
-    mat4 view_proj;
-};
+#include "camera.slang"
 
 layout(location = 0) in vec3 inPosition;
 layout(location = 1) in vec3 inNormal;
@@ -14,5 +12,5 @@ void main() {
     vec4 world = model * vec4(inPosition, 1.0);
     worldPos = world.xyz;
     normal = mat3(model) * inNormal;
-    gl_Position = view_proj * world;
+    gl_Position = KOJI_cameras[0].view_proj * world;
 }

--- a/src/material/compute_pipeline_builder.rs
+++ b/src/material/compute_pipeline_builder.rs
@@ -5,9 +5,13 @@ use std::collections::HashMap;
 /// Internal defaults for auto-registered resources
 enum DefaultResource {
     Time,
+    Cameras,
 }
 
-const DEFAULT_RESOURCES: &[(&str, DefaultResource)] = &[("KOJI_time", DefaultResource::Time)];
+const DEFAULT_RESOURCES: &[(&str, DefaultResource)] = &[
+    ("KOJI_time", DefaultResource::Time),
+    ("KOJI_cameras", DefaultResource::Cameras),
+];
 
 pub struct CPSO {
     pub pipeline: Handle<ComputePipeline>,
@@ -197,6 +201,15 @@ impl<'a> ComputePipelineBuilder<'a> {
                         if res.get("KOJI_time").is_none() && res.get("time").is_none() {
                             res.register_time_buffers(ctx);
                             if let Some(ResourceBinding::Uniform(h)) = res.get("time") {
+                                let handle = *h;
+                                res.bindings.insert((*name).to_string(), ResourceBinding::Uniform(handle));
+                            }
+                        }
+                    }
+                    DefaultResource::Cameras => {
+                        if res.get("KOJI_cameras").is_none() && res.get("cameras").is_none() {
+                            res.register_camera_buffers(ctx);
+                            if let Some(ResourceBinding::Uniform(h)) = res.get("cameras") {
                                 let handle = *h;
                                 res.bindings.insert((*name).to_string(), ResourceBinding::Uniform(handle));
                             }

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -11,9 +11,13 @@ use spirv_reflect::ShaderModule;
 
 enum DefaultResource {
     Time,
+    Cameras,
 }
 
-const DEFAULT_RESOURCES: &[(&str, DefaultResource)] = &[("KOJI_time", DefaultResource::Time)];
+const DEFAULT_RESOURCES: &[(&str, DefaultResource)] = &[
+    ("KOJI_time", DefaultResource::Time),
+    ("KOJI_cameras", DefaultResource::Cameras),
+];
 
 /// Map SPIR-V reflect format to shader primitive enum
 pub(crate) fn reflect_format_to_shader_primitive(fmt: ReflectFormat) -> ShaderPrimitiveType {
@@ -505,6 +509,16 @@ impl<'a> PipelineBuilder<'a> {
                         if res.get("KOJI_time").is_none() && res.get("time").is_none() {
                             res.register_time_buffers(ctx);
                             if let Some(ResourceBinding::Uniform(h)) = res.get("time") {
+                                let handle = *h;
+                                res.bindings
+                                    .insert((*name).to_string(), ResourceBinding::Uniform(handle));
+                            }
+                        }
+                    }
+                    DefaultResource::Cameras => {
+                        if res.get("KOJI_cameras").is_none() && res.get("cameras").is_none() {
+                            res.register_camera_buffers(ctx);
+                            if let Some(ResourceBinding::Uniform(h)) = res.get("cameras") {
                                 let handle = *h;
                                 res.bindings
                                     .insert((*name).to_string(), ResourceBinding::Uniform(handle));

--- a/tests/data/test_camera.frag
+++ b/tests/data/test_camera.frag
@@ -1,0 +1,4 @@
+#version 450
+#include "../../assets/shaders/camera.slang"
+layout(location=0) out vec4 o;
+void main(){ o = KOJI_cameras[0].cam_pos; }


### PR DESCRIPTION
## Summary
- add `camera.slang` header providing `KOJI_cameras` UBO array
- auto-register camera buffers in pipeline builders and renderer
- expose `Renderer::set_camera` API and update shaders/examples

## Testing
- `cargo test` *(fails: build stalled compiling shaderc-sys)*

------
https://chatgpt.com/codex/tasks/task_e_68a112fde0d0832a9bc5dd17a1721a6a