### PR TITLE
Add rendering workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ It provides helpers for building render pipelines, loading `glTF` assets and dra
 SPIR-V shaders are compiled at build time via `inline-spirv` and winit is used for windowing.
 
 
+## Rendering Workflow
+
+See [docs/rendering_workflow.md](docs/rendering_workflow.md) for a guide to
+device creation, texture setup, pipeline configuration, synchronization, proper
+resource destruction, and how to drive these steps using Koji's `Renderer` and
+`RenderGraph` APIs when building your own engine.
+
 ## Dependencies
 
 Key dependencies include:

--- a/docs/rendering_workflow.md
+++ b/docs/rendering_workflow.md
@@ -1,0 +1,93 @@
+# Rendering Workflow
+
+This guide outlines the typical Vulkan workflow used by Koji and how to drive it
+from Koji's API. It covers initialization, resource creation, drawing, and
+cleanup when building your own renderer on top of Koji.
+
+## Core Koji Components
+
+- **gpu::Context** – low level access to Vulkan (re-exported from Dashi).
+- **Renderer** – orchestrates frame submission and presentation.
+- **RenderGraph** or **Canvas** – describe render targets and pass ordering.
+- **TextureManager** / `texture_manager` helpers – load textures with mip levels.
+
+## Context and Device Initialization
+
+1. Use `gpu::DeviceSelector` to choose a physical device and create a
+   `gpu::Context`.
+2. Enable validation layers when available.
+3. Load function pointers through the entry and instance to avoid using
+   uninitialized symbols.
+4. Pass the `Context` into `Renderer::with_graph` or `Renderer::with_canvas`
+   when constructing your renderer.
+
+```rust
+let device = gpu::DeviceSelector::new()?.select(gpu::DeviceFilter::default())?;
+let mut ctx = gpu::Context::new(&gpu::ContextInfo { device })?;
+let graph = RenderGraph::new(); // or build from YAML/JSON
+let mut renderer = Renderer::with_graph(800, 600, &mut ctx, graph)?;
+```
+
+## Texture Creation
+
+1. Allocate an image with the desired format and usage flags.
+2. Specify the correct number of `mipLevels` when creating the image.
+3. Upload the base level data and generate remaining mip levels with blits or
+   compute shaders.
+4. Transition each mip level to the layout expected by the pipeline.
+5. With Koji, prefer using `texture_manager::load_from_file` or
+   `TextureManager::register_image` to handle mip generation and resource
+   bindings.
+
+## Render Pass and Pipeline Setup
+
+1. Define a render pass describing color and depth–stencil attachments. Koji
+   provides `RenderPassBuilder` and `RenderGraph` nodes to do this declaratively.
+2. Create a pipeline layout with descriptor set and push constant ranges.
+3. Build a graphics pipeline that references shader stages and the render pass
+   via `PipelineBuilder`.
+4. Configure dynamic state (viewport, scissor, etc.) so they can be changed per
+   frame.
+5. Set depth–stencil state to match the attachments’ formats and desired compare
+   operations.
+
+## Frame Submission, Synchronization, and Presentation
+
+1. Register meshes or text with the `Renderer` and call `present_frame` each
+   loop iteration.
+2. `present_frame` acquires the next swapchain image, records the render graph
+   into command buffers, and submits work, signaling semaphores and optional
+   fences.
+3. Present the swapchain image once rendering is complete.
+
+```rust
+event_loop.run(move |event, _, control_flow| {
+    match event {
+        Event::MainEventsCleared => renderer.present_frame(&mut ctx).unwrap(),
+        Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
+            *control_flow = ControlFlow::Exit;
+        }
+        _ => {}
+    }
+});
+```
+
+## Resource Cleanup
+
+Destroy resources in reverse order of creation after waiting for the device to
+idle:
+
+1. Semaphores and fences
+2. Swapchains
+3. Surfaces
+4. Logical device
+5. Vulkan instance
+
+`Renderer::destroy` will release its own resources, but you are responsible for
+calling `ctx.destroy()` afterwards.
+
+## Developer Checklist
+
+- [ ] Run `cargo test` and ensure all tests pass.
+- [ ] Run with validation layers enabled and confirm **0** validation errors.
+

--- a/examples/pbr_spheres/README.md
+++ b/examples/pbr_spheres/README.md
@@ -1,0 +1,14 @@
+# pbr_spheres
+
+Renders a grid of spheres demonstrating PBR shading.
+
+See [Rendering Workflow](../../docs/rendering_workflow.md) for an overview of
+context creation, pipeline setup, proper cleanup, and how Koji's APIs fit
+together when building your own renderer.
+
+Run with:
+
+```bash
+cargo run --example pbr_spheres
+```
+


### PR DESCRIPTION
## Summary
- document device and pipeline setup, frame submission, and cleanup
- link rendering workflow guide from root and `pbr_spheres` example
- expand workflow guide with Koji APIs for engine authors

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d0241fac832ab8bbb09791297650