### PR TITLE
Serialize canvases and reconstruct render graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Render passes can now be described with a [`RenderGraph`](src/render_graph/mod.r
 `#[deprecated]`. Prefer constructing graph nodes and connecting them
 to form the frame pipeline.
 
+Graphs may be constructed directly in code or loaded from configuration files.
+Use `render_graph::to_yaml`/`to_json` to serialize an existing graph and
+`render_graph::from_yaml`/`from_json` to rebuild it, including all `Canvas`
+descriptors, from YAML or JSON.
+
 Example descriptions of a lightweight graph can be found in
 [examples/graph_basic.yaml](examples/graph_basic.yaml) and
 [examples/graph_basic.json](examples/graph_basic.json). These files

--- a/src/render_graph/io.rs
+++ b/src/render_graph/io.rs
@@ -1,13 +1,15 @@
 use super::{RenderGraph, SerializableRenderGraph};
+use dashi::gpu::Context;
 
 pub fn to_yaml(graph: &RenderGraph) -> Result<String, serde_yaml::Error> {
     let desc = SerializableRenderGraph::from(graph);
     serde_yaml::to_string(&desc)
 }
 
-pub fn from_yaml(data: &str) -> Result<RenderGraph, serde_yaml::Error> {
-    let desc: SerializableRenderGraph = serde_yaml::from_str(data)?;
-    Ok(RenderGraph::from(desc))
+pub fn from_yaml(ctx: &mut Context, data: &str) -> Result<RenderGraph, String> {
+    let desc: SerializableRenderGraph =
+        serde_yaml::from_str(data).map_err(|e| e.to_string())?;
+    RenderGraph::from_desc(desc, ctx).map_err(|e| format!("{:?}", e))
 }
 
 pub fn to_json(graph: &RenderGraph) -> Result<String, serde_json::Error> {
@@ -15,7 +17,8 @@ pub fn to_json(graph: &RenderGraph) -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&desc)
 }
 
-pub fn from_json(data: &str) -> Result<RenderGraph, serde_json::Error> {
-    let desc: SerializableRenderGraph = serde_json::from_str(data)?;
-    Ok(RenderGraph::from(desc))
+pub fn from_json(ctx: &mut Context, data: &str) -> Result<RenderGraph, String> {
+    let desc: SerializableRenderGraph =
+        serde_json::from_str(data).map_err(|e| e.to_string())?;
+    RenderGraph::from_desc(desc, ctx).map_err(|e| format!("{:?}", e))
 }

--- a/tests/canvas_io.rs
+++ b/tests/canvas_io.rs
@@ -1,17 +1,27 @@
-use koji::canvas::{CanvasDesc, to_yaml, from_yaml, to_json, from_json};
+use dashi::Format;
+use koji::canvas::{AttachmentDesc, CanvasDesc, from_json, from_yaml, to_json, to_yaml};
 
 #[test]
 fn canvas_yaml_roundtrip() {
-    let desc = CanvasDesc { attachments: vec!["color".into(), "depth".into()] };
+    let desc = CanvasDesc {
+        extent: [1, 1],
+        attachments: vec![
+            AttachmentDesc { name: "color".into(), format: Format::RGBA8 },
+            AttachmentDesc { name: "depth".into(), format: Format::D24S8 },
+        ],
+    };
     let yaml = to_yaml(&desc).unwrap();
     let loaded = from_yaml(&yaml).unwrap();
-    assert_eq!(desc.attachments, loaded.attachments);
+    assert_eq!(desc, loaded);
 }
 
 #[test]
 fn canvas_json_roundtrip() {
-    let desc = CanvasDesc { attachments: vec!["color".into()] };
+    let desc = CanvasDesc {
+        extent: [1, 1],
+        attachments: vec![AttachmentDesc { name: "color".into(), format: Format::RGBA8 }],
+    };
     let json = to_json(&desc).unwrap();
     let loaded = from_json(&json).unwrap();
-    assert_eq!(desc.attachments, loaded.attachments);
+    assert_eq!(desc, loaded);
 }

--- a/tests/render_graph.rs
+++ b/tests/render_graph.rs
@@ -44,12 +44,38 @@ fn render_graph_executes_with_composition() {
 }
 
 #[test]
+#[serial]
 fn graph_yaml_roundtrip() {
+    let mut ctx = setup_ctx();
+    let canvas = CanvasBuilder::new()
+        .extent([1, 1])
+        .color_attachment("img", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
     let mut graph = RenderGraph::new();
-    graph.register_external_image("img", Format::RGBA8);
+    graph.add_canvas(&canvas);
     let yaml = koji::render_graph::to_yaml(&graph).unwrap();
-    let loaded = koji::render_graph::from_yaml(&yaml).unwrap();
+    let loaded = koji::render_graph::from_yaml(&mut ctx, &yaml).unwrap();
     assert_eq!(graph.node_names(), loaded.node_names());
+    assert_eq!(loaded.output_images(), vec!["img".to_string()]);
+    ctx.destroy();
+}
+
+#[test]
+#[serial]
+fn graph_json_roundtrip() {
+    let mut ctx = setup_ctx();
+    let canvas = CanvasBuilder::new()
+        .extent([1, 1])
+        .color_attachment("img", Format::RGBA8)
+        .build(&mut ctx)
+        .unwrap();
+    let mut graph = RenderGraph::new();
+    graph.add_canvas(&canvas);
+    let json = koji::render_graph::to_json(&graph).unwrap();
+    let loaded = koji::render_graph::from_json(&mut ctx, &json).unwrap();
+    assert_eq!(loaded.output_images(), vec!["img".to_string()]);
+    ctx.destroy();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- track attachment formats and extents in `CanvasDesc`
- add `Canvas::from_desc` and rebuild canvases when deserializing a `RenderGraph`
- document programmatic vs. config-based render graph setup

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a239ac7314832ab6c311ed52088c3a