### PR TITLE
Add per-attachment clear values for canvases

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -34,6 +34,12 @@ pub struct CanvasOutput<'a> {
 pub struct AttachmentDesc {
     pub name: String,
     pub format: Format,
+    #[serde(default)]
+    pub clear_color: Option<[f32; 4]>,
+    #[serde(default)]
+    pub clear_depth: Option<f32>,
+    #[serde(default)]
+    pub clear_stencil: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -46,15 +52,30 @@ impl From<&Canvas> for CanvasDesc {
     fn from(c: &Canvas) -> Self {
         let mut attachments = Vec::new();
         for att in c.target.colors.iter() {
+            let clear_color = match att.attachment.clear {
+                ClearValue::Color(c) => Some(c),
+                ClearValue::IntColor(_) => None,
+                _ => None,
+            };
             attachments.push(AttachmentDesc {
                 name: att.name.clone(),
                 format: att.format,
+                clear_color,
+                clear_depth: None,
+                clear_stencil: None,
             });
         }
         if let Some(depth) = &c.target.depth {
+            let (clear_depth, clear_stencil) = match depth.attachment.clear {
+                ClearValue::DepthStencil { depth, stencil } => (Some(depth), Some(stencil)),
+                _ => (None, None),
+            };
             attachments.push(AttachmentDesc {
                 name: depth.name.clone(),
                 format: depth.format,
+                clear_color: None,
+                clear_depth,
+                clear_stencil,
             });
         }
         Self {
@@ -98,7 +119,18 @@ impl Canvas {
         let mut builder = CanvasBuilder::new().extent(desc.extent);
         for att in &desc.attachments {
             if matches!(att.format, Format::D24S8) {
-                builder = builder.depth_attachment(att.name.clone(), att.format);
+                if att.clear_depth.is_some() || att.clear_stencil.is_some() {
+                    builder = builder.depth_attachment_with_clear(
+                        att.name.clone(),
+                        att.format,
+                        att.clear_depth.unwrap_or(1.0),
+                        att.clear_stencil.unwrap_or(0),
+                    );
+                } else {
+                    builder = builder.depth_attachment(att.name.clone(), att.format);
+                }
+            } else if let Some(color) = att.clear_color {
+                builder = builder.color_attachment_with_clear(att.name.clone(), att.format, color);
             } else {
                 builder = builder.color_attachment(att.name.clone(), att.format);
             }
@@ -111,6 +143,8 @@ impl Canvas {
 pub struct CanvasBuilder {
     builder: RenderPassBuilder,
     color_names: Vec<String>,
+    color_clears: IndexMap<String, [f32; 4]>,
+    depth_clear: Option<(String, f32, u32)>,
     extent: [u32; 2],
 }
 
@@ -142,9 +176,36 @@ impl CanvasBuilder {
         self
     }
 
+    pub fn color_attachment_with_clear(
+        mut self,
+        name: impl Into<String>,
+        format: Format,
+        clear: [f32; 4],
+    ) -> Self {
+        let n = name.into();
+        self.builder = self.builder.color_attachment(n.clone(), format);
+        self.color_names.push(n.clone());
+        self.color_clears.insert(n, clear);
+        self
+    }
+
     pub fn depth_attachment(mut self, name: impl Into<String>, format: Format) -> Self {
         let n = name.into();
         self.builder = self.builder.depth_attachment(n.clone(), format);
+        self.depth_clear = Some((n, 1.0, 0));
+        self
+    }
+
+    pub fn depth_attachment_with_clear(
+        mut self,
+        name: impl Into<String>,
+        format: Format,
+        depth: f32,
+        stencil: u32,
+    ) -> Self {
+        let n = name.into();
+        self.builder = self.builder.depth_attachment(n.clone(), format);
+        self.depth_clear = Some((n, depth, stencil));
         self
     }
 
@@ -152,7 +213,17 @@ impl CanvasBuilder {
         let sub_colors = self.color_names.clone();
         self.builder = self.builder.subpass("main", sub_colors, &[] as &[&str]);
         let (rp, mut targets, all) = self.builder.build_with_images(ctx)?;
-        let target = targets.remove(0);
+        let mut target = targets.remove(0);
+        for att in &mut target.colors {
+            if let Some(clear) = self.color_clears.get(&att.name) {
+                att.attachment.clear = ClearValue::Color(*clear);
+            }
+        }
+        if let Some((ref name, depth, stencil)) = self.depth_clear {
+            if let Some(depth_att) = target.depth.as_mut().filter(|a| &a.name == name) {
+                depth_att.attachment.clear = ClearValue::DepthStencil { depth, stencil };
+            }
+        }
         let mut attachments = IndexMap::new();
         for att in all.attachments {
             attachments.insert(att.name.clone(), att);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -239,18 +239,6 @@ impl Renderer {
             }
         }
 
-        for canvas in &mut canvases {
-            for att in &mut canvas.target_mut().colors {
-                att.attachment.clear = ClearValue::Color(renderer.clear_color);
-            }
-            if let Some(depth) = &mut canvas.target_mut().depth {
-                depth.attachment.clear = ClearValue::DepthStencil {
-                    depth: renderer.clear_depth,
-                    stencil: 0,
-                };
-            }
-        }
-
         renderer.canvases = canvases;
         renderer.graph = graph;
 

--- a/tests/canvas_io.rs
+++ b/tests/canvas_io.rs
@@ -1,13 +1,25 @@
 use dashi::Format;
-use koji::canvas::{AttachmentDesc, CanvasDesc, from_json, from_yaml, to_json, to_yaml};
+use koji::canvas::{from_json, from_yaml, to_json, to_yaml, AttachmentDesc, CanvasDesc};
 
 #[test]
 fn canvas_yaml_roundtrip() {
     let desc = CanvasDesc {
         extent: [1, 1],
         attachments: vec![
-            AttachmentDesc { name: "color".into(), format: Format::RGBA8 },
-            AttachmentDesc { name: "depth".into(), format: Format::D24S8 },
+            AttachmentDesc {
+                name: "color".into(),
+                format: Format::RGBA8,
+                clear_color: None,
+                clear_depth: None,
+                clear_stencil: None,
+            },
+            AttachmentDesc {
+                name: "depth".into(),
+                format: Format::D24S8,
+                clear_color: None,
+                clear_depth: None,
+                clear_stencil: None,
+            },
         ],
     };
     let yaml = to_yaml(&desc).unwrap();
@@ -19,7 +31,13 @@ fn canvas_yaml_roundtrip() {
 fn canvas_json_roundtrip() {
     let desc = CanvasDesc {
         extent: [1, 1],
-        attachments: vec![AttachmentDesc { name: "color".into(), format: Format::RGBA8 }],
+        attachments: vec![AttachmentDesc {
+            name: "color".into(),
+            format: Format::RGBA8,
+            clear_color: None,
+            clear_depth: None,
+            clear_stencil: None,
+        }],
     };
     let json = to_json(&desc).unwrap();
     let loaded = from_json(&json).unwrap();


### PR DESCRIPTION
## Summary
- allow specifying clear color and depth/stencil values for canvas attachments
- avoid overriding canvas clear values in the renderer
- serialize clear values in canvas descriptions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a252ad9c98832a8db60b8e4307d10a