### PR TITLE
Fix descriptor counts for runtime descriptor arrays

### DIFF
--- a/src/material/compute_pipeline_builder.rs
+++ b/src/material/compute_pipeline_builder.rs
@@ -248,21 +248,28 @@ impl<'a> ComputePipelineBuilder<'a> {
 
                 let var_type = descriptor_to_var_type(b.ty);
                 let mut count = b.count;
-                if count == 0 {
-                    if let Some(ref mut r) = res {
-                        if let Some(binding_entry) = r.get(&b.name) {
-                            count = match binding_entry {
-                                ResourceBinding::TextureArray(arr) => arr.len() as u32,
-                                ResourceBinding::CombinedTextureArray(arr) => arr.len() as u32,
-                                ResourceBinding::BufferArray(arr) => arr.lock().unwrap().len() as u32,
-                                _ => 0,
-                            };
+
+                // Similar to the graphics pipeline builder, account for unsized
+                // descriptor arrays by using the number of resources registered with
+                // the ResourceManager when it is larger than the reflected count.
+                if let Some(ref mut r) = res {
+                    if let Some(binding_entry) = r.get(&b.name) {
+                        let array_len = match binding_entry {
+                            ResourceBinding::TextureArray(arr) => arr.len() as u32,
+                            ResourceBinding::CombinedTextureArray(arr) => arr.len() as u32,
+                            ResourceBinding::BufferArray(arr) => arr.lock().unwrap().len() as u32,
+                            _ => 0,
+                        };
+                        if array_len > count {
+                            count = array_len;
                         }
                     }
-                    if count == 0 {
-                        count = 1;
-                    }
                 }
+
+                if count == 0 {
+                    count = 1;
+                }
+
                 vars.push(BindGroupVariable {
                     var_type,
                     binding: b.binding,

--- a/src/material/compute_pipeline_builder.rs
+++ b/src/material/compute_pipeline_builder.rs
@@ -13,6 +13,10 @@ const DEFAULT_RESOURCES: &[(&str, DefaultResource)] = &[
     ("KOJI_cameras", DefaultResource::Cameras),
 ];
 
+/// Default size used for runtime descriptor arrays when no resource data is
+/// available at pipeline creation time.
+const DEFAULT_DESCRIPTOR_ARRAY_CAPACITY: u32 = 64;
+
 pub struct CPSO {
     pub pipeline: Handle<ComputePipeline>,
     pub layout: Handle<ComputePipelineLayout>,
@@ -81,9 +85,7 @@ impl CPSO {
                                 slot: i as u32,
                             })
                             .collect();
-                        if *count > 1 {
-                            data.truncate(*count as usize);
-                        }
+                        data.truncate(*count as usize);
                         all_indexed_data.push(data);
                         which_binding.push((all_indexed_data.len() - 1, *binding as usize));
                     }
@@ -97,9 +99,7 @@ impl CPSO {
                                 slot: i as u32,
                             })
                             .collect();
-                        if *count > 1 {
-                            data.truncate(*count as usize);
-                        }
+                        data.truncate(*count as usize);
                         all_indexed_data.push(data);
                         which_binding.push((all_indexed_data.len() - 1, *binding as usize));
                     }
@@ -113,9 +113,7 @@ impl CPSO {
                                 slot: i as u32,
                             })
                             .collect();
-                        if *count > 1 {
-                            data.truncate(*count as usize);
-                        }
+                        data.truncate(*count as usize);
                         all_indexed_data.push(data);
                         which_binding.push((all_indexed_data.len() - 1, *binding as usize));
                     }
@@ -267,7 +265,11 @@ impl<'a> ComputePipelineBuilder<'a> {
                 }
 
                 if count == 0 {
-                    count = 1;
+                    count = if res.is_some() {
+                        1
+                    } else {
+                        DEFAULT_DESCRIPTOR_ARRAY_CAPACITY
+                    };
                 }
 
                 vars.push(BindGroupVariable {

--- a/src/material/pipeline_builder.rs
+++ b/src/material/pipeline_builder.rs
@@ -19,6 +19,11 @@ const DEFAULT_RESOURCES: &[(&str, DefaultResource)] = &[
     ("KOJI_cameras", DefaultResource::Cameras),
 ];
 
+/// Fallback size for runtime descriptor arrays when no resource information is
+/// available during pipeline creation. This should be large enough to cover
+/// typical use cases while staying within reasonable descriptor limits.
+const DEFAULT_DESCRIPTOR_ARRAY_CAPACITY: u32 = 64;
+
 /// Map SPIR-V reflect format to shader primitive enum
 pub(crate) fn reflect_format_to_shader_primitive(fmt: ReflectFormat) -> ShaderPrimitiveType {
     use ReflectFormat::*;
@@ -333,9 +338,7 @@ impl PSO {
                                 slot: i as u32,
                             })
                             .collect();
-                        if *count > 1 {
-                            data.truncate(*count as usize);
-                        }
+                        data.truncate(*count as usize);
                         all_indexed_data.push(data);
                         which_binding.push((all_indexed_data.len() - 1, *binding as usize));
                     }
@@ -349,9 +352,7 @@ impl PSO {
                                 slot: i as u32,
                             })
                             .collect();
-                        if *count > 1 {
-                            data.truncate(*count as usize);
-                        }
+                        data.truncate(*count as usize);
 
                         all_indexed_data.push(data);
                         which_binding.push((all_indexed_data.len() - 1, *binding as usize));
@@ -366,9 +367,7 @@ impl PSO {
                                 slot: i as u32,
                             })
                             .collect();
-                        if *count > 1 {
-                            data.truncate(*count as usize);
-                        }
+                        data.truncate(*count as usize);
 
                         all_indexed_data.push(data);
 
@@ -608,7 +607,11 @@ impl<'a> PipelineBuilder<'a> {
                 }
 
                 if count == 0 {
-                    count = 1;
+                    count = if res.is_some() {
+                        1
+                    } else {
+                        DEFAULT_DESCRIPTOR_ARRAY_CAPACITY
+                    };
                 }
 
                 vars.push(BindGroupVariable {


### PR DESCRIPTION
## Summary
- ensure descriptor array counts match registered resources in pipeline builders
- handle unsized descriptor arrays correctly to prevent descriptor set overflows

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a25cf84568832a9a537ecc4b16559c