### PR TITLE
Add render graph builder and configuration loader helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,34 @@ Render passes can now be described with a [`RenderGraph`](src/render_graph/mod.r
 `#[deprecated]`. Prefer constructing graph nodes and connecting them
 to form the frame pipeline.
 
-Graphs may be constructed directly in code or loaded from configuration files.
+[`RenderGraphBuilder`](src/render_graph/builder.rs) offers a fluent API for
+assembling graphs in code:
+
+```rust
+use koji::render_graph::RenderGraphBuilder;
+use koji::canvas::CanvasBuilder;
+use dashi::gpu::Format;
+
+let canvas = CanvasBuilder::new()
+    .extent([800, 600])
+    .color_attachment("color", Format::RGBA8)
+    .build(&mut ctx)?;
+let mut builder = RenderGraphBuilder::new();
+builder.add_canvas(&canvas);
+let graph = builder.build();
+```
+
+Graphs may also be loaded from configuration files.
+`Renderer::with_graph_from_yaml` and `Renderer::with_graph_from_json`
+create a renderer directly from serialized graphs:
+
+```rust
+use koji::renderer::Renderer;
+
+let data = std::fs::read_to_string("graph_basic.yaml")?;
+let mut renderer = Renderer::with_graph_from_yaml(800, 600, &mut ctx, &data)?;
+```
+
 Use `render_graph::to_yaml`/`to_json` to serialize an existing graph and
 `render_graph::from_yaml`/`from_json` to rebuild it, including all `Canvas`
 descriptors, from YAML or JSON.

--- a/docs/rendering_workflow.md
+++ b/docs/rendering_workflow.md
@@ -24,8 +24,17 @@ cleanup when building your own renderer on top of Koji.
 ```rust
 let device = gpu::DeviceSelector::new()?.select(gpu::DeviceFilter::default())?;
 let mut ctx = gpu::Context::new(&gpu::ContextInfo { device })?;
-let graph = RenderGraph::new(); // or build from YAML/JSON
+let canvas = CanvasBuilder::new()
+    .extent([800, 600])
+    .color_attachment("color", Format::RGBA8)
+    .build(&mut ctx)?;
+let graph = RenderGraphBuilder::new()
+    .add_canvas(&canvas)
+    .build();
 let mut renderer = Renderer::with_graph(800, 600, &mut ctx, graph)?;
+// or load directly from configuration:
+// let yaml = std::fs::read_to_string("graph_basic.yaml")?;
+// let mut renderer = Renderer::with_graph_from_yaml(800, 600, &mut ctx, &yaml)?;
 ```
 
 ## Texture Creation

--- a/src/render_graph/builder.rs
+++ b/src/render_graph/builder.rs
@@ -1,0 +1,61 @@
+use super::{GraphNode, RenderGraph};
+use crate::canvas::Canvas;
+use dashi::gpu::Format;
+
+/// Convenience builder for assembling a [`RenderGraph`].
+///
+/// ```no_run
+/// # use koji::render_graph::RenderGraphBuilder;
+/// # use koji::canvas::CanvasBuilder;
+/// # use dashi::gpu::{Context, Format};
+/// # fn build_graph(ctx: &mut Context) -> Result<(), dashi::GPUError> {
+/// let canvas = CanvasBuilder::new()
+///     .extent([800, 600])
+///     .color_attachment("color", Format::RGBA8)
+///     .build(ctx)?;
+/// let mut builder = RenderGraphBuilder::new();
+/// builder.add_canvas(&canvas);
+/// let graph = builder.build();
+/// # Ok(()) }
+/// ```
+pub struct RenderGraphBuilder {
+    graph: RenderGraph,
+}
+
+impl RenderGraphBuilder {
+    /// Create a new empty builder.
+    pub fn new() -> Self {
+        Self {
+            graph: RenderGraph::new(),
+        }
+    }
+
+    /// Insert a generic [`GraphNode`] into the graph.
+    pub fn add_node<N: GraphNode + 'static>(&mut self, node: N) -> &mut Self {
+        self.graph.add_node(node);
+        self
+    }
+
+    /// Add a [`Canvas`] to the graph.
+    pub fn add_canvas(&mut self, canvas: &Canvas) -> &mut Self {
+        self.graph.add_canvas(canvas);
+        self
+    }
+
+    /// Register an external image resource by name and format.
+    pub fn register_external_image(&mut self, name: &str, format: Format) -> &mut Self {
+        self.graph.register_external_image(name, format);
+        self
+    }
+
+    /// Connect two nodes by name.
+    pub fn connect(&mut self, from: &str, to: &str) -> &mut Self {
+        self.graph.connect(from, to);
+        self
+    }
+
+    /// Finalize and return the constructed [`RenderGraph`].
+    pub fn build(self) -> RenderGraph {
+        self.graph
+    }
+}

--- a/src/render_graph/mod.rs
+++ b/src/render_graph/mod.rs
@@ -26,6 +26,8 @@ mod composition;
 pub use composition::*;
 pub mod io;
 pub use io::*;
+pub mod builder;
+pub use builder::*;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ResourceDesc {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -287,6 +287,44 @@ impl Renderer {
         Self::with_graph_internal(width, height, ctx, graph, true)
     }
 
+    /// Construct a [`Renderer`] from a render graph described in YAML.
+    ///
+    /// ```no_run
+    /// # use koji::renderer::Renderer;
+    /// # use dashi::gpu::Context;
+    /// # fn build(ctx: &mut Context, yaml: &str) -> Result<(), String> {
+    /// let renderer = Renderer::with_graph_from_yaml(800, 600, ctx, yaml)?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_graph_from_yaml(
+        width: u32,
+        height: u32,
+        ctx: &mut Context,
+        data: &str,
+    ) -> Result<Self, String> {
+        let graph = crate::render_graph::from_yaml(ctx, data)?;
+        Self::with_graph(width, height, ctx, graph).map_err(|e| format!("{:?}", e))
+    }
+
+    /// Construct a [`Renderer`] from a render graph described in JSON.
+    ///
+    /// ```no_run
+    /// # use koji::renderer::Renderer;
+    /// # use dashi::gpu::Context;
+    /// # fn build(ctx: &mut Context, json: &str) -> Result<(), String> {
+    /// let renderer = Renderer::with_graph_from_json(800, 600, ctx, json)?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_graph_from_json(
+        width: u32,
+        height: u32,
+        ctx: &mut Context,
+        data: &str,
+    ) -> Result<Self, String> {
+        let graph = crate::render_graph::from_json(ctx, data)?;
+        Self::with_graph(width, height, ctx, graph).map_err(|e| format!("{:?}", e))
+    }
+
     pub fn new(width: u32, height: u32, _title: &str, ctx: &mut Context) -> Result<Self, GPUError> {
         let canvas = CanvasBuilder::new()
             .extent([width, height])


### PR DESCRIPTION
## Summary
- add `RenderGraphBuilder` for assembling graphs with `add_canvas`, `connect`, etc.
- load render graphs in `Renderer` directly from YAML or JSON configs
- document builder and loader usage with examples

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a918404240832aa11a5fed6b6b1d96